### PR TITLE
Fix inconsistent page naming

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
@@ -5,6 +5,15 @@
         public AppShell()
         {
             InitializeComponent();
+
+            // register application routes
+            Routing.RegisterRoute(nameof(BeaconPage), typeof(QiMata.MobileIoT.Views.BeaconPage));
+            Routing.RegisterRoute(nameof(BlePage), typeof(QiMata.MobileIoT.Views.BlePage));
+            Routing.RegisterRoute(nameof(NfcPage), typeof(QiMata.MobileIoT.Views.NfcPage));
+            Routing.RegisterRoute(nameof(NfcP2PPage), typeof(QiMata.MobileIoT.Views.NfcP2PPage));
+            Routing.RegisterRoute(nameof(SerialPage), typeof(QiMata.MobileIoT.Views.SerialPage));
+            Routing.RegisterRoute(nameof(UsbPage), typeof(QiMata.MobileIoT.Views.UsbPage));
+            Routing.RegisterRoute(nameof(WifiDirectPage), typeof(QiMata.MobileIoT.Views.WifiDirectPage));
         }
     }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BeaconPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BeaconPage.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="QiMata.MobileIoT.Views.Beacon"
-             Title="Beacon">
+            x:Class="QiMata.MobileIoT.Views.BeaconPage"
+            Title="BeaconPage">
     <VerticalStackLayout>
         <Label 
             Text="Welcome to .NET MAUI!"

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BeaconPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BeaconPage.xaml.cs
@@ -1,9 +1,9 @@
 namespace QiMata.MobileIoT.Views;
 
-public partial class Beacon : ContentPage
+public partial class BeaconPage : ContentPage
 {
-	public Beacon()
-	{
-		InitializeComponent();
-	}
+        public BeaconPage()
+        {
+                InitializeComponent();
+        }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BlePage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BlePage.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="QiMata.MobileIoT.Views.BleView"
-             Title="BleView">
+            x:Class="QiMata.MobileIoT.Views.BlePage"
+            Title="BlePage">
     <VerticalStackLayout>
         <Label 
             Text="Welcome to .NET MAUI!"

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BlePage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BlePage.xaml.cs
@@ -1,9 +1,9 @@
 namespace QiMata.MobileIoT.Views;
 
-public partial class BleView : ContentPage
+public partial class BlePage : ContentPage
 {
-	public BleView()
-	{
-		InitializeComponent();
-	}
+        public BlePage()
+        {
+                InitializeComponent();
+        }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Views/NfcP2PPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/NfcP2PPage.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="QiMata.MobileIoT.Views.NfcP2P"
-             Title="NfcP2P">
+            x:Class="QiMata.MobileIoT.Views.NfcP2PPage"
+            Title="NfcP2PPage">
     <VerticalStackLayout>
         <Label 
             Text="Welcome to .NET MAUI!"

--- a/src/MobileIoT/QiMata.MobileIoT/Views/NfcP2PPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/NfcP2PPage.xaml.cs
@@ -1,9 +1,9 @@
 namespace QiMata.MobileIoT.Views;
 
-public partial class NfcP2P : ContentPage
+public partial class NfcP2PPage : ContentPage
 {
-	public NfcP2P()
-	{
-		InitializeComponent();
-	}
+        public NfcP2PPage()
+        {
+                InitializeComponent();
+        }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Views/WifiDirectPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/WifiDirectPage.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="QiMata.MobileIoT.Views.WifiDirectView"
-             Title="WifiDirectView">
+            x:Class="QiMata.MobileIoT.Views.WifiDirectPage"
+            Title="WifiDirectPage">
     <VerticalStackLayout>
         <Label 
             Text="Welcome to .NET MAUI!"

--- a/src/MobileIoT/QiMata.MobileIoT/Views/WifiDirectPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/WifiDirectPage.xaml.cs
@@ -1,9 +1,9 @@
 namespace QiMata.MobileIoT.Views;
 
-public partial class WifiDirectView : ContentPage
+public partial class WifiDirectPage : ContentPage
 {
-	public WifiDirectView()
-	{
-		InitializeComponent();
-	}
+        public WifiDirectPage()
+        {
+                InitializeComponent();
+        }
 }


### PR DESCRIPTION
## Summary
- rename classes and titles to use `Page` suffix
- update AppShell route registration accordingly

## Testing
- `dotnet build src/MobileIoT/MobileIoT.sln -c Release` *(fails: `dotnet` not found)*