### PR TITLE
Add Bluetooth classic service

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -15,6 +15,8 @@ namespace QiMata.MobileIoT
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
 
+            builder.Services.AddSingleton<Services.I.IBluetoothClassicService, Services.BluetoothClassicService>();
+
 #if DEBUG
     		builder.Logging.AddDebug();
 #endif

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -59,9 +59,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+                <PackageReference Include="Moq" Version="4.20.72" />
+                <PackageReference Include="InTheHand.Net.Bluetooth" Version="4.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="Services\I\" />

--- a/src/MobileIoT/QiMata.MobileIoT/Services/BluetoothClassicService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/BluetoothClassicService.cs
@@ -1,0 +1,87 @@
+using InTheHand.Net.Bluetooth;
+using InTheHand.Net.Sockets;
+using System.Text;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT.Services
+{
+    public class BluetoothClassicService : IBluetoothClassicService
+    {
+        private BluetoothClient? _bluetoothClient;
+        private BluetoothDeviceInfo? _connectedDevice;
+
+        public async Task<IEnumerable<string>> GetPairedDevicesAsync()
+        {
+            return await Task.Run(() =>
+            {
+                var client = new BluetoothClient();
+                var devices = client.DiscoverDevices();
+                return devices.Select(d => d.DeviceName);
+            });
+        }
+
+        public async Task ConnectToDeviceAsync(string deviceName)
+        {
+            await Task.Run(() =>
+            {
+                var client = new BluetoothClient();
+                var devices = client.DiscoverDevices();
+                var device = devices.FirstOrDefault(d => d.DeviceName == deviceName);
+
+                if (device == null)
+                {
+                    throw new Exception("Device not found.");
+                }
+
+                _connectedDevice = device;
+                _bluetoothClient = new BluetoothClient();
+                _bluetoothClient.Connect(device.DeviceAddress, BluetoothService.SerialPort);
+            });
+        }
+
+        public async Task DisconnectAsync()
+        {
+            if (_bluetoothClient != null)
+            {
+                await Task.Run(() =>
+                {
+                    _bluetoothClient.Close();
+                    _bluetoothClient = null;
+                    _connectedDevice = null;
+                });
+            }
+        }
+
+        public async Task SendDataAsync(string data)
+        {
+            if (_bluetoothClient == null || !_bluetoothClient.Connected)
+            {
+                throw new InvalidOperationException("No device connected.");
+            }
+
+            await Task.Run(() =>
+            {
+                var stream = _bluetoothClient!.GetStream();
+                var bytes = Encoding.UTF8.GetBytes(data);
+                stream.Write(bytes, 0, bytes.Length);
+                stream.Flush();
+            });
+        }
+
+        public async Task<string> ReceiveDataAsync()
+        {
+            if (_bluetoothClient == null || !_bluetoothClient.Connected)
+            {
+                throw new InvalidOperationException("No device connected.");
+            }
+
+            return await Task.Run(() =>
+            {
+                var stream = _bluetoothClient!.GetStream();
+                var buffer = new byte[1024];
+                var bytesRead = stream.Read(buffer, 0, buffer.Length);
+                return Encoding.UTF8.GetString(buffer, 0, bytesRead);
+            });
+        }
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/IBluetoothClassicService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/IBluetoothClassicService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace QiMata.MobileIoT.Services.I
+{
+    public interface IBluetoothClassicService
+    {
+        Task<IEnumerable<string>> GetPairedDevicesAsync();
+        Task ConnectToDeviceAsync(string deviceName);
+        Task DisconnectAsync();
+        Task SendDataAsync(string data);
+        Task<string> ReceiveDataAsync();
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockBluetoothClassicService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockBluetoothClassicService.cs
@@ -1,0 +1,39 @@
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT.Services.Mock
+{
+    public class MockBluetoothClassicService : IBluetoothClassicService
+    {
+        private readonly Queue<string> _receivedData = new();
+        private readonly List<string> _pairedDevices = new() { "Mock Device" };
+        public Task<IEnumerable<string>> GetPairedDevicesAsync()
+        {
+            return Task.FromResult<IEnumerable<string>>(_pairedDevices);
+        }
+
+        public Task ConnectToDeviceAsync(string deviceName)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task SendDataAsync(string data)
+        {
+            _receivedData.Enqueue(data);
+            return Task.CompletedTask;
+        }
+
+        public Task<string> ReceiveDataAsync()
+        {
+            if (_receivedData.Count == 0)
+            {
+                return Task.FromResult(string.Empty);
+            }
+            return Task.FromResult(_receivedData.Dequeue());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `IBluetoothClassicService` with common Bluetooth operations
- implement `BluetoothClassicService` using InTheHand.Net.Bluetooth
- provide `MockBluetoothClassicService` for testing
- register the service in `MauiProgram`
- reference the `InTheHand.Net.Bluetooth` package

## Testing
- `dotnet build src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj -c Release` *(fails: `dotnet` not found)*
- `dotnet test src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj` *(fails: `dotnet` not found)*