### PR TITLE
Add BLE sensor/LED control page

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
@@ -7,6 +7,7 @@
             InitializeComponent();
 
             // register application routes
+            Routing.RegisterRoute(nameof(BleSensorControlPage), typeof(BleSensorControlPage));
             Routing.RegisterRoute(nameof(BeaconPage), typeof(QiMata.MobileIoT.Views.BeaconPage));
             Routing.RegisterRoute(nameof(BlePage), typeof(QiMata.MobileIoT.Views.BlePage));
             Routing.RegisterRoute(nameof(NfcPage), typeof(QiMata.MobileIoT.Views.NfcPage));

--- a/src/MobileIoT/QiMata.MobileIoT/BleSensorControlPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/BleSensorControlPage.xaml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="QiMata.MobileIoT.BleSensorControlPage"
+             BackgroundColor="#F3F4F6"
+             Title="BLE Sensor &amp; LED">
+
+    <Grid Padding="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <VerticalStackLayout>
+            <Label Text="BLE Sensor &amp; LED Control"
+                   FontSize="26"
+                   FontAttributes="Bold"
+                   TextColor="#374151"
+                   HorizontalOptions="Center"
+                   Margin="0,20"/>
+        </VerticalStackLayout>
+
+        <!-- Content -->
+        <ScrollView Grid.Row="1">
+            <Frame BackgroundColor="White"
+                   CornerRadius="10"
+                   Padding="20"
+                   HasShadow="True">
+                <VerticalStackLayout Spacing="20">
+
+                    <!-- DHT22 Sensor -->
+                    <Label Text="DHT22 Sensor"
+                           FontSize="20"
+                           FontAttributes="Bold"
+                           TextColor="#374151" />
+
+                    <Label Text="{Binding Temperature, StringFormat='Temperature: {0} °C'}"
+                           FontSize="18"
+                           TextColor="#111827"/>
+
+                    <Label Text="{Binding Humidity, StringFormat='Humidity: {0}%'}"
+                           FontSize="18"
+                           TextColor="#111827"/>
+
+                    <Button Text="Refresh Sensor"
+                            BackgroundColor="#2563EB"
+                            TextColor="White"
+                            CornerRadius="8"
+                            Command="{Binding RefreshSensorCommand}" />
+
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#E5E7EB"
+                             Margin="0,10"/>
+
+                    <!-- LED Control -->
+                    <Label Text="LED Control"
+                           FontSize="20"
+                           FontAttributes="Bold"
+                           TextColor="#374151" />
+
+                    <Button Text="{Binding LedButtonText}"
+                            BackgroundColor="{Binding LedButtonColor}"
+                            TextColor="White"
+                            CornerRadius="8"
+                            Command="{Binding ToggleLedCommand}" />
+
+                    <Label Text="{Binding LedStatus}"
+                           FontSize="18"
+                           TextColor="#111827"
+                           HorizontalOptions="Center"
+                           Margin="0,10"/>
+
+                    <!-- Back -->
+                    <Button Text="Back"
+                            BackgroundColor="#6B7280"
+                            TextColor="White"
+                            CornerRadius="8"
+                            Command="{Binding NavigateBackCommand}" />
+                </VerticalStackLayout>
+            </Frame>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/src/MobileIoT/QiMata.MobileIoT/BleSensorControlPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/BleSensorControlPage.xaml.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT;
+
+public partial class BleSensorControlPage : ContentPage
+{
+    public BleSensorControlPage(BleSensorControlViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/BleSensorControlViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/BleSensorControlViewModel.cs
@@ -1,0 +1,46 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Controls;
+
+namespace QiMata.MobileIoT;
+
+public partial class BleSensorControlViewModel : ObservableObject
+{
+    private readonly IBleService _ble;
+
+    public BleSensorControlViewModel(IBleService ble)
+    {
+        _ble = ble;
+        LedButtonText  = "Turn LED On";
+        LedButtonColor = Color.FromArgb("#2563EB");
+        LedStatus      = "LED is Off";
+    }
+
+    // --- DHT22 bindables ---
+    [ObservableProperty] private double _temperature;
+    [ObservableProperty] private double _humidity;
+
+    // --- LED bindables ---
+    [ObservableProperty] private string _ledButtonText;
+    [ObservableProperty] private Color  _ledButtonColor;
+    [ObservableProperty] private string _ledStatus;
+
+    // --- Commands ---
+    [RelayCommand]
+    private async Task RefreshSensor()
+    {
+        (Temperature, Humidity) = await _ble.ReadDht22Async();
+    }
+
+    [RelayCommand]
+    private async Task ToggleLed()
+    {
+        bool isOn = await _ble.ToggleLedAsync();
+        LedStatus      = isOn ? "LED is On" : "LED is Off";
+        LedButtonText  = isOn ? "Turn LED Off" : "Turn LED On";
+        LedButtonColor = isOn ? Color.FromArgb("#DC2626") : Color.FromArgb("#2563EB");
+    }
+
+    [RelayCommand]
+    private Task NavigateBack() => Shell.Current.GoToAsync("..");
+}

--- a/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
@@ -26,10 +26,16 @@
 
             <Button
                 x:Name="CounterBtn"
-                Text="Click me" 
+                Text="Click me"
                 SemanticProperties.Hint="Counts the number of times you click"
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Fill" />
+            <Button Text="BLE Sensor &amp; LED"
+                    BackgroundColor="#2563EB"
+                    TextColor="White"
+                    CornerRadius="8"
+                    Command="{Binding NavigateCommand}"
+                    CommandParameter="BleSensorControlPage" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml.cs
@@ -3,10 +3,10 @@
     public partial class MainPage : ContentPage
     {
         int count = 0;
-
-        public MainPage()
+        public MainPage(MainPageViewModel vm)
         {
             InitializeComponent();
+            BindingContext = vm;
         }
 
         private void OnCounterClicked(object sender, EventArgs e)

--- a/src/MobileIoT/QiMata.MobileIoT/MainPageViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPageViewModel.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace QiMata.MobileIoT;
+
+public partial class MainPageViewModel : ObservableObject
+{
+    [RelayCommand]
+    private async Task Navigate(string target)
+    {
+        await OnNavigate(target);
+    }
+
+    private async Task OnNavigate(string target)
+    {
+        switch (target)
+        {
+            case "BleSensorControlPage":
+                await Shell.Current.GoToAsync(nameof(BleSensorControlPage));
+                break;
+            default:
+                await Shell.Current.GoToAsync(target);
+                break;
+        }
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace QiMata.MobileIoT
 {
@@ -16,8 +17,12 @@ namespace QiMata.MobileIoT
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
+            builder.Services.AddSingleton<IBleService, BleService>();
+            builder.Services.AddTransient<BleSensorControlViewModel>();
+            builder.Services.AddTransient<BleSensorControlPage>();
+            builder.Services.AddTransient<MainPageViewModel>();
 
             return builder.Build();
         }

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -58,10 +58,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+                <PackageReference Include="Moq" Version="4.20.72" />
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="Services\I\" />

--- a/src/MobileIoT/QiMata.MobileIoT/Services/BleService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/BleService.cs
@@ -1,0 +1,15 @@
+namespace QiMata.MobileIoT;
+
+public class BleService : IBleService
+{
+    public Task<(double temp, double humidity)> ReadDht22Async()
+        => Task.FromResult<(double temp, double humidity)>((23.4, 56.7)); // TODO real BLE read
+
+    private bool _ledState;
+    public Task<bool> ToggleLedAsync()
+    {
+        _ledState = !_ledState;
+        // TODO write value over BLE
+        return Task.FromResult(_ledState);
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/IBleService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/IBleService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace QiMata.MobileIoT;
+
+public interface IBleService
+{
+    Task<(double temp, double humidity)> ReadDht22Async();
+    Task<bool> ToggleLedAsync();
+}


### PR DESCRIPTION
## Summary
- add navigation button on main page for BLE sensor & LED controls
- implement MainPageViewModel with new route handling
- register BleSensorControlPage route in `AppShell`
- create BLE sensor control page and viewmodel with placeholder service
- wire up dependency injection for service and viewmodels
- add CommunityToolkit.Mvvm dependency

## Testing
- `dotnet build` *(fails: `dotnet` not found)*