### PR TITLE
Add NFC tag read/write support

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -4,6 +4,7 @@ using QiMata.MobileIoT.Services.I;
 using QiMata.MobileIoT.Services.Mock;
 using QiMata.MobileIoT.Services;
 using QiMata.MobileIoT.Views;
+using Plugin.NFC;
 
 namespace QiMata.MobileIoT
 {
@@ -28,8 +29,16 @@ namespace QiMata.MobileIoT
             builder.Services.AddSingleton<IBluetoothService, BluetoothService>();
             builder.Services.AddSingleton<IBleDemoService, BleDemoService>();
 #endif
+            
+#if ANDROID
+            builder.Services.AddSingleton<INfcService, AndroidNfcService>();
+#elif IOS
+            builder.Services.AddSingleton<INfcService, IosNfcService>();
+#endif
+
             builder.Services.AddTransient<ViewModels.BleViewModel>();
             builder.Services.AddTransient<BlePage>();
+            builder.Services.AddTransient<Views.NfcPage>();
 
             return builder.Build();
         }

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -8,4 +8,22 @@
         <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
         <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+        <uses-permission android:name="android.permission.NFC" />
+        <uses-feature android:name="android.hardware.nfc" android:required="true" />
+
+  <application android:label="MyMauiApp">
+    <activity android:name="crc64fa985e60e8a4f16e.MainActivity"
+              android:exported="true"
+              android:launchMode="singleTop">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="text/plain" />
+      </intent-filter>
+    </activity>
+  </application>
 </manifest>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidNfcService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidNfcService.cs
@@ -1,0 +1,59 @@
+#if ANDROID
+using Android.Content;
+using Android.Nfc;
+using Microsoft.Maui.Controls;
+using Plugin.NFC;
+using System.Linq;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT;
+
+public class AndroidNfcService : Java.Lang.Object, INfcService
+{
+    public bool IsAvailable => CrossNFC.Current.IsAvailable;
+    public bool IsEnabled   => CrossNFC.Current.IsEnabled;
+
+    public Task StartListeningAsync()
+    {
+        CrossNFC.Current.OnMessageReceived += OnMessageReceived;
+        CrossNFC.Current.StartListening();
+        return Task.CompletedTask;
+    }
+
+    public Task StopListeningAsync()
+    {
+        CrossNFC.Current.OnMessageReceived -= OnMessageReceived;
+        CrossNFC.Current.StopListening();
+        return Task.CompletedTask;
+    }
+
+    public Task WriteTextAsync(string text)
+    {
+        var record = NFCNdefRecord.CreateTextRecord(text);
+        var msg    = new NFCNdefMessage { Records = new[] { record } };
+
+        CrossNFC.Current.OnTagDiscovered += async (tagInfo, format) =>
+        {
+            await CrossNFC.Current.PublishMessage(msg);
+        };
+
+        CrossNFC.Current.StartPublishing();
+        return Task.CompletedTask;
+    }
+
+    void OnMessageReceived(ITagInfo tagInfo)
+    {
+        if (!tagInfo.IsSupported) return;
+
+        var first = tagInfo.Records?.FirstOrDefault();
+        if (first?.TypeFormat == NFCNdefTypeFormat.WellKnown)
+        {
+            var payloadText = first.Message;
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                Application.Current.MainPage.DisplayAlert("Tag Read", payloadText, "OK");
+            });
+        }
+    }
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/MainActivity.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/MainActivity.cs
@@ -1,11 +1,25 @@
-﻿using Android.App;
+using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
+using Plugin.NFC;
 
-namespace QiMata.MobileIoT
+namespace QiMata.MobileIoT;
+
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
+          ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
+          ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
-    public class MainActivity : MauiAppCompatActivity
+    protected override void OnCreate(Bundle savedInstanceState)
     {
+        base.OnCreate(savedInstanceState);
+        CrossNFC.Init(this);
+    }
+
+    protected override void OnNewIntent(Intent intent)
+    {
+        base.OnNewIntent(intent);
+        CrossNFC.OnNewIntent(intent);
     }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Entitlements.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>NDEF</string>
+    </array>
+</dict>
+</plist>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -10,9 +10,10 @@
 		<integer>2</integer>
 	</array>
 	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
+        <array>
+                <string>arm64</string>
+                <string>nfc</string>
+        </array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -30,5 +31,7 @@
 <string>Assets.xcassets/appicon.appiconset</string>
 <key>NSBluetoothAlwaysUsageDescription</key>
 <string>Needed to connect to environmental sensor.</string>
+<key>NFCReaderUsageDescription</key>
+<string>This app uses NFC to read and write tags.</string>
 </dict>
 </plist>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/IosNfcService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/IosNfcService.cs
@@ -1,0 +1,60 @@
+#if IOS
+using CoreFoundation;
+using CoreNFC;
+using Foundation;
+using Microsoft.Maui.Controls;
+using System.Linq;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT;
+
+public class IosNfcService : NSObject, INfcService, INFCNdefReaderSessionDelegate, INFCNdefTag
+{
+    NFCNdefReaderSession? session;
+    TaskCompletionSource? writerTcs;
+
+    public bool IsAvailable => NFCNdefReaderSession.ReadingAvailable;
+    public bool IsEnabled   => IsAvailable;
+
+    public Task StartListeningAsync()
+    {
+        session = new NFCNdefReaderSession(this, null, true);
+        session?.BeginSession();
+        return Task.CompletedTask;
+    }
+
+    public Task StopListeningAsync()
+    {
+        session?.InvalidateSession();
+        return Task.CompletedTask;
+    }
+
+    public Task WriteTextAsync(string text)
+    {
+        writerTcs = new TaskCompletionSource();
+        session   = new NFCNdefReaderSession(this, null, false);
+        session?.BeginSession();
+        return writerTcs.Task;
+    }
+
+    public void DidDetect(NFCNdefReaderSession s, NFCNdefMessage[] messages)
+    {
+        foreach (var msg in messages)
+        {
+            foreach (var rec in msg.Records)
+            {
+                var payload = rec.Payload.Skip(1).ToArray();
+                var text = System.Text.Encoding.UTF8.GetString(payload);
+                MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    Application.Current.MainPage.DisplayAlert("Tag Read", text, "OK");
+                });
+            }
+        }
+    }
+
+    public void DidInvalidate(NFCNdefReaderSession s, NSError error) { }
+
+    public void DidDetectTags(NFCTagReaderSession s, INFCTag[] tags) { }
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -60,14 +60,25 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-                <PackageReference Include="Plugin.BLE" Version="3.1.0" />
-                <PackageReference Include="Moq" Version="4.20.72" />
-                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
-        </ItemGroup>
+        <PackageReference Include="Plugin.BLE" Version="3.1.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
+        <PackageReference Include="Plugin.NFC" Version="2.0.0" />
+      </ItemGroup>
 
         <ItemGroup>
-                <TrimmerRootAssembly Include="Plugin.BLE" />
-        </ItemGroup>
+        <TrimmerRootAssembly Include="Plugin.BLE" />
+      </ItemGroup>
+
+      <!-- Android permissions + feature -->
+      <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
+        <AndroidManifest Include="Platforms\Android\AndroidManifest.xml" />
+      </ItemGroup>
+
+      <!-- iOS NFC entitlements -->
+      <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+        <MauiEntitlements Include="Platforms\iOS\Entitlements.plist" />
+      </ItemGroup>
 
 	<ItemGroup>
 	  <Compile Update="Views\BlePage.xaml.cs">

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/INfcService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/INfcService.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT.Services.I;
+
+public interface INfcService
+{
+    bool IsAvailable { get; }
+    bool IsEnabled { get; }
+    Task StartListeningAsync();
+    Task StopListeningAsync();
+    Task WriteTextAsync(string text);
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Views/NfcPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/NfcPage.xaml
@@ -3,10 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="QiMata.MobileIoT.Views.NfcPage"
              Title="NfcPage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+  <VerticalStackLayout Spacing="12" Padding="24">
+    <Label Text="NFC Demo" FontAttributes="Bold" FontSize="24"/>
+    <Entry x:Name="EntryText" Placeholder="Text to write" />
+    <Button Text="Start Scan"   Clicked="OnStartClicked" />
+    <Button Text="Stop Scan"    Clicked="OnStopClicked" />
+    <Button Text="Write Tag"    Clicked="OnWriteClicked" />
+  </VerticalStackLayout>
 </ContentPage>

--- a/src/MobileIoT/QiMata.MobileIoT/Views/NfcPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/NfcPage.xaml.cs
@@ -1,9 +1,40 @@
+using QiMata.MobileIoT.Services.I;
+
 namespace QiMata.MobileIoT.Views;
 
 public partial class NfcPage : ContentPage
 {
-	public NfcPage()
-	{
-		InitializeComponent();
-	}
+    readonly INfcService _nfc;
+
+    public NfcPage(INfcService nfc)
+    {
+        InitializeComponent();
+        _nfc = nfc;
+    }
+
+    async void OnStartClicked(object sender, EventArgs e)
+    {
+        if (!_nfc.IsAvailable)
+        {
+            await DisplayAlert("NFC", "Not available!", "OK");
+            return;
+        }
+        if (!_nfc.IsEnabled)
+        {
+            await DisplayAlert("NFC", "Please enable NFC", "OK");
+            return;
+        }
+        await _nfc.StartListeningAsync();
+    }
+
+    async void OnStopClicked(object sender, EventArgs e)
+    {
+        await _nfc.StopListeningAsync();
+    }
+
+    async void OnWriteClicked(object sender, EventArgs e)
+    {
+        var txt = EntryText.Text ?? string.Empty;
+        await _nfc.WriteTextAsync(txt);
+    }
 }


### PR DESCRIPTION
## Summary
- integrate `Plugin.NFC` into the project
- register new `INfcService` interface with Android/iOS implementations
- declare Android NFC permissions and iOS NFC entitlement
- update `Info.plist` with NFC usage keys
- add a simple NFC demo page

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*