### PR TITLE
Implement beacon scanning

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -26,9 +26,19 @@ namespace QiMata.MobileIoT
             builder.Services.AddSingleton<IBleDemoService>(MockServiceFactory.CreateBleDemoService());
             builder.Services.AddSingleton<IBluetoothService>(MockServiceFactory.CreateBluetoothService());
             builder.Services.AddSingleton<INfcService>(MockServiceFactory.CreateNfcService());
+#if ANDROID
+            builder.Services.AddSingleton<IBeaconScanner, BeaconScanner_Android>();
+#elif IOS
+            builder.Services.AddSingleton<IBeaconScanner, BeaconScanner_iOS>();
+#endif
 #else
             builder.Services.AddSingleton<IBluetoothService, BluetoothService>();
             builder.Services.AddSingleton<IBleDemoService, BleDemoService>();
+#if ANDROID
+            builder.Services.AddSingleton<IBeaconScanner, BeaconScanner_Android>();
+#elif IOS
+            builder.Services.AddSingleton<IBeaconScanner, BeaconScanner_iOS>();
+#endif
 #if ANDROID
             builder.Services.AddSingleton<INfcService, AndroidNfcService>();
 #elif IOS

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -1,13 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         <uses-permission android:name="android.permission.INTERNET" />
-        <uses-permission android:name="android.permission.BLUETOOTH" />
-        <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-        <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-        <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" tools:targetApi="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
         <uses-permission android:name="android.permission.NFC" />
         <uses-feature android:name="android.hardware.nfc" android:required="true" />
 
@@ -26,4 +25,5 @@
       </intent-filter>
     </activity>
   </application>
+
 </manifest>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/BeaconScanner_Android.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/BeaconScanner_Android.cs
@@ -1,0 +1,53 @@
+#if ANDROID
+using Android.Bluetooth;
+using Android.Bluetooth.LE;
+using Android.Runtime;
+using Java.Util;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+public sealed class BeaconScanner_Android : Java.Lang.Object, IBeaconScanner
+{
+    readonly BluetoothLeScanner _scanner;
+    readonly ScanCallbackImpl   _callback;
+    public event EventHandler<BeaconAdvertisement>? AdvertisementReceived;
+    public bool IsScanning { get; private set; }
+
+    public BeaconScanner_Android()
+    {
+        var adapter = BluetoothAdapter.DefaultAdapter
+                     ?? throw new InvalidOperationException("Bluetooth unavailable");
+        _scanner  = adapter.BluetoothLeScanner!;
+        _callback = new ScanCallbackImpl(OnAdv);
+    }
+
+    public void StartScanning()
+    {
+        if (IsScanning) return;
+        _scanner.StartScan(_callback);
+        IsScanning = true;
+    }
+
+    public void StopScanning()
+    {
+        if (!IsScanning) return;
+        _scanner.StopScan(_callback);
+        IsScanning = false;
+    }
+
+    void OnAdv(ScanResult result)
+    {
+        var data = result?.ScanRecord?.GetBytes();
+        if (data?.Length > 0)
+            AdvertisementReceived?.Invoke(this, new BeaconAdvertisement(data, result.Rssi));
+    }
+
+    sealed class ScanCallbackImpl : ScanCallback
+    {
+        readonly Action<ScanResult> _on;
+        public ScanCallbackImpl(Action<ScanResult> on) => _on = on;
+        public override void OnScanResult(ScanCallbackType t, ScanResult r) => _on(r);
+    }
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/BeaconScanner_iOS.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/BeaconScanner_iOS.cs
@@ -1,0 +1,47 @@
+#if IOS
+using CoreBluetooth;
+using Foundation;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT.Platforms.iOS;
+
+public sealed class BeaconScanner_iOS : NSObject, IBeaconScanner, ICBCentralManagerDelegate
+{
+    readonly CBCentralManager _central;
+    public event EventHandler<BeaconAdvertisement>? AdvertisementReceived;
+    public bool IsScanning { get; private set; }
+
+    public BeaconScanner_iOS() =>
+        _central = new CBCentralManager(this, DispatchQueue.MainQueue);
+
+    public void StartScanning()
+    {
+        if (IsScanning || _central.State != CBCentralManagerState.PoweredOn) return;
+        var opts = new PeripheralScanningOptions { AllowDuplicatesKey = true };
+        _central.ScanForPeripherals(peripheralUuids: null, options: opts);
+        IsScanning = true;
+    }
+
+    public void StopScanning()
+    {
+        if (!IsScanning) return;
+        _central.StopScan();
+        IsScanning = false;
+    }
+
+    [Export("centralManagerDidUpdateState:")]
+    public void UpdatedState(CBCentralManager central)
+    {
+        if (central.State == CBCentralManagerState.PoweredOn) StartScanning();
+    }
+
+    [Export("centralManager:didDiscoverPeripheral:advertisementData:RSSI:")]
+    public void DiscoveredPeripheral(CBCentralManager c, CBPeripheral p,
+                                     NSDictionary ad, NSNumber rssi)
+    {
+        if (ad[CBAdvertisement.DataManufacturerDataKey] is NSData d && d.Length > 0)
+            AdvertisementReceived?.Invoke(this,
+                new BeaconAdvertisement(d.ToArray(), rssi.Int32Value));
+    }
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -30,7 +30,7 @@
 <key>XSAppIconAssets</key>
 <string>Assets.xcassets/appicon.appiconset</string>
 <key>NSBluetoothAlwaysUsageDescription</key>
-<string>Needed to connect to environmental sensor.</string>
+<string>Scanning nearby BLE beacons.</string>
 <key>NFCReaderUsageDescription</key>
 <string>This app uses NFC to read and write tags.</string>
 </dict>

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/IBeaconScanner.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/IBeaconScanner.cs
@@ -1,0 +1,11 @@
+namespace QiMata.MobileIoT.Services.I;
+
+public record BeaconAdvertisement(byte[] Data, int Rssi);
+
+public interface IBeaconScanner
+{
+    event EventHandler<BeaconAdvertisement> AdvertisementReceived;
+    void StartScanning();
+    void StopScanning();
+    bool IsScanning { get; }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/PermissionsHelper.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/PermissionsHelper.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui.ApplicationModel;
+
+namespace QiMata.MobileIoT.Services;
+
+public static class PermissionsHelper
+{
+    public static async Task EnsureBlePermissionsAsync()
+    {
+#if ANDROID
+        if (DeviceInfo.Version.Major >= 12)
+            await Permissions.RequestAsync<Permissions.BluetoothScan>();
+        else
+            await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+#endif
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/MainPageViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/MainPageViewModel.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+using Microsoft.Maui;
+using Microsoft.Maui.Dispatching;
+using System.Collections.ObjectModel;
+using System.Linq;
+using QiMata.MobileIoT.Services.I;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public class MainPageViewModel : ObservableObject
+{
+    readonly IBeaconScanner _scanner;
+
+    public ObservableCollection<string> BeaconLogs { get; } = new();
+
+    public MainPageViewModel(IBeaconScanner scanner)
+    {
+        _scanner = scanner;
+        _scanner.AdvertisementReceived += OnAd;
+        _scanner.StartScanning();
+    }
+
+    void OnAd(object? s, BeaconAdvertisement e)
+    {
+        var preview = BitConverter.ToString(e.Data.Take(4).ToArray());
+        MainThread.BeginInvokeOnMainThread(() =>
+            BeaconLogs.Add($"{DateTime.Now:T}  RSSI {e.Rssi}  {preview}"));
+    }
+}


### PR DESCRIPTION
## Summary
- add cross-platform `IBeaconScanner` interface and platform implementations
- log raw advertisements in `MainPageViewModel`
- register scanners in `MauiProgram`
- request BLE permissions at runtime
- update Android and iOS manifests

## Testing
- `dotnet build` *(fails: `dotnet` not found)*