### PR TITLE
Add NFC P2P send/receive event

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Services/NfcP2PService_Android.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Services/NfcP2PService_Android.cs
@@ -13,12 +13,16 @@ public class NfcP2PService_Android : Java.Lang.Object,
                                      NfcAdapter.IOnNdefPushCompleteCallback
 {
     NfcAdapter? _adapter;
+    string _textToSend = string.Empty;
 
-    public void StartP2P()
+    public event EventHandler<NfcMessageEventArgs>? MessageReceived;
+
+    public void StartP2P(string textToSend)
     {
+        _textToSend = textToSend ?? string.Empty;   // save for CreateNdefMessage
         var activity = Platform.CurrentActivity ?? MauiApplication.Current.GetActivity();
         _adapter = NfcAdapter.GetDefaultAdapter(activity);
-        if (_adapter == null || activity == null) return;     // device has no NFC
+        if (_adapter == null) return;
 
         _adapter.SetNdefPushMessageCallback(this, activity);
         _adapter.SetOnNdefPushCompleteCallback(this, activity);
@@ -29,26 +33,41 @@ public class NfcP2PService_Android : Java.Lang.Object,
         var activity = Platform.CurrentActivity ?? MauiApplication.Current.GetActivity();
         if (_adapter == null || activity == null)
         {
-            return; 
+            return;
         }
         _adapter?.SetNdefPushMessageCallback(null, activity);
         _adapter?.SetOnNdefPushCompleteCallback(null, activity);
     }
 
-    // Builds the message sent to the peer
+    // Build the NDEF to beam, using the caller-supplied text
     public NdefMessage CreateNdefMessage(NfcEvent e)
     {
-        const string payloadText = "Hello from .NET MAUI";
         var mimeType = System.Text.Encoding.ASCII.GetBytes("application/vnd.yourapp.p2p");
-        var payload   = System.Text.Encoding.UTF8.GetBytes(payloadText);
-
-        var record = new NdefRecord(NdefRecord.TnfMimeMedia, mimeType, Array.Empty<byte>(), payload);
+        var payload  = System.Text.Encoding.UTF8.GetBytes(_textToSend);
+        var record   = new NdefRecord(NdefRecord.TnfMimeMedia, mimeType, Array.Empty<byte>(), payload);
         return new NdefMessage(new[] { record });
     }
 
-    // Optional confirmation callback
-    public void OnNdefPushComplete(NfcEvent e)
-    {
+    public void OnNdefPushComplete(NfcEvent e) =>
         System.Diagnostics.Debug.WriteLine("NDEF push completed.");
+
+    // Called from MainActivity to parse incoming intents
+    internal void HandleIntent(Android.Content.Intent intent)
+    {
+        if (!NfcAdapter.ActionNdefDiscovered.Equals(intent.Action)) return;
+
+        var raw = intent.GetParcelableArrayExtra(NfcAdapter.ExtraNdefMessages);
+        if (raw?.Length > 0)
+        {
+            var msg    = (NdefMessage)raw[0]!;
+            var record = msg.GetRecords().FirstOrDefault();
+            if (record == null) return;
+
+            var mimeType = System.Text.Encoding.ASCII.GetString(record.GetType());
+            var text     = System.Text.Encoding.UTF8.GetString(record.GetPayload());
+
+            MessageReceived?.Invoke(this,
+                new NfcMessageEventArgs(mimeType, text, record.GetPayload()));
+        }
     }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Services/NfcP2PService_iOS.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Services/NfcP2PService_iOS.cs
@@ -5,8 +5,10 @@ namespace QiMata.MobileIoT.Platforms.iOS;
 
 public class NfcP2PService_iOS : INfcP2PService
 {
-    public void StartP2P() =>
-        throw new NotSupportedException("NFC peer-to-peer is not available on iOS.");
+    public event EventHandler<NfcMessageEventArgs>? MessageReceived;
+
+    public void StartP2P(string _) =>
+        throw new NotSupportedException("NFC peer-to-peer is not supported on iOS.");
 
     public void StopP2P() { }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/INfcP2PService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/INfcP2PService.cs
@@ -2,6 +2,32 @@ namespace QiMata.MobileIoT.Services.I;
 
 public interface INfcP2PService
 {
-    void StartP2P();
+    /// <summary>
+    /// Begin advertising the specified text as an NDEF MIME record.
+    /// </summary>
+    /// <param name="textToSend">Text payload to advertise.</param>
+    void StartP2P(string textToSend);
+
+    /// <summary>Stop advertising / unregister callbacks.</summary>
     void StopP2P();
+
+    /// <summary>
+    /// Raised when an NDEF message arrives from a peer.
+    /// </summary>
+    event EventHandler<NfcMessageEventArgs> MessageReceived;
+}
+
+/// <summary>Details extracted from an incoming NDEF record.</summary>
+public sealed class NfcMessageEventArgs : EventArgs
+{
+    public string MimeType { get; }
+    public string Text { get; }
+    public byte[] RawPayload { get; }
+
+    public NfcMessageEventArgs(string mimeType, string text, byte[] rawPayload)
+    {
+        MimeType = mimeType;
+        Text = text;
+        RawPayload = rawPayload;
+    }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockServiceFactory.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockServiceFactory.cs
@@ -102,7 +102,7 @@ namespace QiMata.MobileIoT.Services.Mock
         public static INfcP2PService CreateNfcP2PService()
         {
             var mock = new Mock<INfcP2PService>();
-            mock.Setup(m => m.StartP2P());
+            mock.Setup(m => m.StartP2P(It.IsAny<string>()));
             mock.Setup(m => m.StopP2P());
             return mock.Object;
         }

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/NfcP2PViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/NfcP2PViewModel.cs
@@ -12,7 +12,7 @@ public partial class NfcP2PViewModel : ObservableObject
     public NfcP2PViewModel(INfcP2PService svc) => _svc = svc;
 
     [RelayCommand]
-    void StartP2P() => _svc.StartP2P();
+    void StartP2P() => _svc.StartP2P("Hello World");
 
     [RelayCommand]
     void NavigateBack() => Shell.Current.GoToAsync("..");


### PR DESCRIPTION
## Summary
- extend INfcP2PService to support sending text and receiving peer data
- implement new functionality for Android peer-to-peer service
- forward NFC intents to the service from MainActivity
- keep iOS implementation as a stub with the new API
- update mock factory and viewmodel for the changed interface

## Testing
- `dotnet build src/MobileIoT/MobileIoT.sln -c Release` *(fails: dotnet not installed)*