### PR TITLE
Add BLE beacon scanner page and update scanner API

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
@@ -10,6 +10,7 @@ namespace QiMata.MobileIoT
 
             // register application routes
             Routing.RegisterRoute(nameof(BeaconPage), typeof(QiMata.MobileIoT.Views.BeaconPage));
+            Routing.RegisterRoute(nameof(BleScannerPage), typeof(QiMata.MobileIoT.Views.BleScannerPage));
             Routing.RegisterRoute(nameof(BlePage), typeof(QiMata.MobileIoT.Views.BlePage));
             Routing.RegisterRoute(nameof(NfcPage), typeof(QiMata.MobileIoT.Views.NfcPage));
             Routing.RegisterRoute(nameof(NfcP2PPage), typeof(QiMata.MobileIoT.Views.NfcP2PPage));

--- a/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
@@ -38,12 +38,12 @@
                             Command="{Binding NavigateCommand}"
                             CommandParameter="BlePage" />
 
-                    <Button Text="Beacon"
+                    <Button Text="BLE Beacons"
                             BackgroundColor="#2563EB"
                             TextColor="White"
                             CornerRadius="8"
                             Command="{Binding NavigateCommand}"
-                            CommandParameter="BeaconPage" />
+                            CommandParameter="BleScannerPage" />
 
                     <Button Text="NFC"
                             BackgroundColor="#2563EB"

--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -54,6 +54,9 @@ namespace QiMata.MobileIoT
             builder.Services.AddTransient<ViewModels.BleViewModel>();
             builder.Services.AddTransient<BlePage>();
 
+            builder.Services.AddTransient<ViewModels.BeaconScanViewModel>();
+            builder.Services.AddTransient<BleScannerPage>();
+
             return builder.Build();
         }
     }

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/BeaconScanner_Android.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/BeaconScanner_Android.cs
@@ -38,9 +38,15 @@ public sealed class BeaconScanner_Android : Java.Lang.Object, IBeaconScanner
 
     void OnAdv(ScanResult result)
     {
-        var data = result?.ScanRecord?.GetBytes();
+        var rec  = result?.ScanRecord;
+        var data = rec?.GetBytes();
         if (data?.Length > 0)
-            AdvertisementReceived?.Invoke(this, new BeaconAdvertisement(data, result.Rssi));
+            AdvertisementReceived?.Invoke(this,
+                new BeaconAdvertisement(
+                    result.Device.Address,
+                    result.Device.Name,
+                    data,
+                    result.Rssi));
     }
 
     sealed class ScanCallbackImpl : ScanCallback

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/BeaconScanner_iOS.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/BeaconScanner_iOS.cs
@@ -42,7 +42,11 @@ public sealed class BeaconScanner_iOS : NSObject, IBeaconScanner, ICBCentralMana
     {
         if (ad[CBAdvertisement.DataManufacturerDataKey] is NSData d && d.Length > 0)
             AdvertisementReceived?.Invoke(this,
-                new BeaconAdvertisement(d.ToArray(), rssi.Int32Value));
+                new BeaconAdvertisement(
+                    p.Identifier.AsString(),
+                    p.Name,
+                    d.ToArray(),
+                    rssi.Int32Value));
     }
 }
 #endif

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -81,12 +81,15 @@
       </ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="Views\BlePage.xaml.cs">
-	    <DependentUpon>BlePage.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Views\BeaconPage.xaml.cs">
-	    <DependentUpon>BeaconPage.xaml</DependentUpon>
-	  </Compile>
+          <Compile Update="Views\BlePage.xaml.cs">
+            <DependentUpon>BlePage.xaml</DependentUpon>
+          </Compile>
+          <Compile Update="Views\BleScannerPage.xaml.cs">
+            <DependentUpon>BleScannerPage.xaml</DependentUpon>
+          </Compile>
+          <Compile Update="Views\BeaconPage.xaml.cs">
+            <DependentUpon>BeaconPage.xaml</DependentUpon>
+          </Compile>
 	  <Compile Update="Views\NfcP2PPage.xaml.cs">
 	    <DependentUpon>NfcP2PPage.xaml</DependentUpon>
 	  </Compile>
@@ -111,9 +114,12 @@
 	  <MauiXaml Update="Views\UsbPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\WifiDirectPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
+          <MauiXaml Update="Views\WifiDirectPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\BleScannerPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+        </ItemGroup>
 
 </Project>

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/IBeaconScanner.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/IBeaconScanner.cs
@@ -1,6 +1,13 @@
 namespace QiMata.MobileIoT.Services.I;
 
-public record BeaconAdvertisement(byte[] Data, int Rssi);
+/// <summary>
+/// Advertisement details from a BLE beacon.
+/// </summary>
+public record BeaconAdvertisement(
+    string DeviceId,
+    string? Name,
+    byte[] Data,
+    int Rssi);
 
 public interface IBeaconScanner
 {

--- a/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockServiceFactory.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/Mock/MockServiceFactory.cs
@@ -153,10 +153,15 @@ namespace QiMata.MobileIoT.Services.Mock
                     var data = new byte[20];
                     random.NextBytes(data);
                     var rssi = random.Next(-100, -20);
+                    var deviceId = $"AA:BB:{random.Next(0,255):X2}:{random.Next(0,255):X2}:{random.Next(0,255):X2}:{random.Next(0,255):X2}";
 
                     mock.Raise(m => m.AdvertisementReceived += null,
                         mock.Object,
-                        new BeaconAdvertisement(data, rssi));
+                        new BeaconAdvertisement(
+                            deviceId,
+                            "MockBeacon",
+                            data,
+                            rssi));
                 }, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(500)); // every 500 ms
             });
 

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/BeaconScanViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/BeaconScanViewModel.cs
@@ -1,0 +1,58 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using QiMata.MobileIoT.Services.I;
+using System.Collections.ObjectModel;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public partial class BeaconScanViewModel : ObservableObject
+{
+    readonly IBeaconScanner _scanner;
+
+    public ObservableCollection<BeaconItemViewModel> Devices { get; } = new();
+
+    public BeaconScanViewModel(IBeaconScanner scanner)
+    {
+        _scanner = scanner;
+        _scanner.AdvertisementReceived += OnAdv;
+        _scanner.StartScanning();
+    }
+
+    void OnAdv(object? s, BeaconAdvertisement adv)
+    {
+        var existing = Devices.FirstOrDefault(d => d.DeviceId == adv.DeviceId);
+        if (existing is null)
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+                Devices.Add(new BeaconItemViewModel(adv)));
+        }
+        else
+        {
+            existing.Update(adv);
+        }
+    }
+}
+
+public class BeaconItemViewModel : ObservableObject
+{
+    public string DeviceId   { get; }
+    public string? Name      { get; private set; }
+    public int    Rssi       { get; private set; }
+    public string DataPreview => BitConverter.ToString(Data.Take(16).ToArray());
+    byte[] Data { get; set; }
+
+    public BeaconItemViewModel(BeaconAdvertisement adv)
+    {
+        DeviceId = adv.DeviceId;
+        Update(adv);
+    }
+
+    public void Update(BeaconAdvertisement adv)
+    {
+        Name = adv.Name;
+        Rssi = adv.Rssi;
+        Data = adv.Data;
+        OnPropertyChanged(nameof(Name));
+        OnPropertyChanged(nameof(Rssi));
+        OnPropertyChanged(nameof(DataPreview));
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BleScannerPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BleScannerPage.xaml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:QiMata.MobileIoT.ViewModels"
+             x:Class="QiMata.MobileIoT.Views.BleScannerPage"
+             Title="BLE Beacons"
+             BackgroundColor="#F3F4F6">
+
+    <Grid Padding="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*"   />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <Label Text="Detected BLE Beacons"
+               FontSize="26"
+               FontAttributes="Bold"
+               TextColor="#374151"
+               HorizontalOptions="Center"
+               Margin="0,20"/>
+
+        <!-- Device list -->
+        <CollectionView Grid.Row="1"
+                        ItemsSource="{Binding Devices}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Frame Margin="0,6"
+                           Padding="12"
+                           CornerRadius="8"
+                           BackgroundColor="White"
+                           HasShadow="True">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="{Binding Name, FallbackValue=(no name)}"
+                                   FontAttributes="Bold"
+                                   FontSize="18"
+                                   TextColor="#111827"/>
+                            <Label Text="{Binding DeviceId}"
+                                   FontSize="12"
+                                   TextColor="#6B7280"/>
+                            <Label Text="{Binding Rssi, StringFormat='RSSI: {0} dBm'}"
+                                   FontSize="14"
+                                   TextColor="#374151"/>
+                            <Label Text="{Binding DataPreview}"
+                                   FontFamily="Courier New"
+                                   FontSize="12"
+                                   TextColor="#2563EB"/>
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</ContentPage>

--- a/src/MobileIoT/QiMata.MobileIoT/Views/BleScannerPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/BleScannerPage.xaml.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT.Views;
+
+public partial class BleScannerPage : ContentPage
+{
+    public BleScannerPage(ViewModels.BeaconScanViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}


### PR DESCRIPTION
## Summary
- extend `BeaconAdvertisement` to include device ID and name
- surface new fields from Android and iOS scanners
- update mock scanner
- implement `BeaconScanViewModel`
- add new `BleScannerPage`
- register new page/viewmodel and route
- hook into main page navigation

## Testing
- `dotnet` was unavailable so no build was performed