### PR TITLE
Add P2P Wi‑Fi and Multipeer services

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -57,6 +57,12 @@ namespace QiMata.MobileIoT
             builder.Services.AddTransient<ViewModels.BeaconScanViewModel>();
             builder.Services.AddTransient<BleScannerPage>();
 
+#if ANDROID
+            builder.Services.AddSingleton<IP2PService, Platforms.Android.WifiDirectService>();
+#elif IOS
+            builder.Services.AddSingleton<IP2PService, Platforms.iOS.MultipeerService>();
+#endif
+
             return builder.Build();
         }
     }

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -3,6 +3,12 @@
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+        <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+        <!-- For API ≤ 32 -->
+        <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+        <!-- For API 33+ -->
+        <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" tools:targetApi="31" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Helpers/PermissionHelper.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Helpers/PermissionHelper.cs
@@ -1,0 +1,38 @@
+using Android.App;
+using Android.Content.PM;
+using Android;
+using AndroidX.Core.App;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace QiMata.MobileIoT.Platforms.Android.Helpers;
+
+public static partial class PermissionHelper
+{
+    public static Task<bool> EnsureWifiDirectPermissionsAsync(Activity activity)
+    {
+        string[] required =
+        {
+            Manifest.Permission.AccessFineLocation,          // API ≤ 32
+            "android.permission.NEARBY_WIFI_DEVICES"         // API 33+
+        };
+
+        var pending = required.Where(p => ActivityCompat.CheckSelfPermission(activity, p) != Permission.Granted)
+                              .ToArray();
+
+        if (pending.Length == 0) return Task.FromResult(true);
+
+        var tcs = new TaskCompletionSource<bool>();
+        ActivityCompat.RequestPermissions(activity, pending, 7001);
+
+        void Handler(object? s, EventArgs e)
+        {
+            activity.RequestPermissionsResult -= Handler;
+            var allGranted = pending.All(p => ActivityCompat.CheckSelfPermission(activity, p) == Permission.Granted);
+            tcs.TrySetResult(allGranted);
+        }
+
+        activity.RequestPermissionsResult += Handler;
+        return tcs.Task;
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/WifiDirectService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/WifiDirectService.cs
@@ -1,0 +1,125 @@
+using Android.Content;
+using Android.Net.Wifi.P2p;
+using QiMata.MobileIoT.Services;
+using QiMata.MobileIoT.Platforms.Android.Helpers;
+using Android.App;
+using Microsoft.Maui.ApplicationModel;
+using Java.Net;
+using Android.OS;
+using Android.Runtime;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Linq;
+using System.Threading;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+public sealed class WifiDirectService : Java.Lang.Object, IP2PService,
+    WifiP2pManager.IActionListener,
+    WifiP2pManager.IPeerListListener,
+    WifiP2pManager.IConnectionInfoListener
+{
+    readonly WifiP2pManager _manager;
+    readonly WifiP2pManager.Channel _channel;
+    readonly BroadcastReceiver _receiver;
+    readonly Context _ctx = Application.Context;
+    TaskCompletionSource<bool>? _pendingDiscover;
+    TaskCompletionSource<bool>? _pendingConnect;
+    Socket? _socket;
+    CancellationTokenSource? _recvCts;
+
+    public WifiDirectService()
+    {
+        _manager = WifiP2pManager.FromContext(_ctx)!;
+        _channel = _manager.Initialize(_ctx, Looper.MainLooper, null);
+        _receiver = new WifiP2pBroadcastReceiver(_manager, _channel, this, this);
+        var filter = new IntentFilter(WifiP2pManager.WifiP2pPeersChangedAction);
+        filter.AddAction(WifiP2pManager.WifiP2pConnectionChangedAction);
+        _ctx.RegisterReceiver(_receiver, filter);
+    }
+
+    public async Task<bool> StartDiscoveryAsync(CancellationToken ct = default)
+    {
+        if (!await PermissionHelper.EnsureWifiDirectPermissionsAsync(Platform.CurrentActivity))
+            return false;
+
+        _pendingDiscover = new();
+        _manager.DiscoverPeers(_channel, this);
+        return await _pendingDiscover.Task.WaitAsync(ct);
+    }
+
+    public Task<bool> ConnectToPeerAsync(string deviceAddress, CancellationToken ct = default)
+    {
+        _pendingConnect = new();
+        var cfg = new WifiP2pConfig { DeviceAddress = deviceAddress };
+        _manager.Connect(_channel, cfg, this);
+        return _pendingConnect.Task.WaitAsync(ct);
+    }
+
+    public async Task<bool> SendAsync(ReadOnlyMemory<byte> buffer, string? peerId = null, CancellationToken ct = default)
+    {
+        if (_socket is null) return false;
+        await _socket.OutputStream.WriteAsync(buffer, ct);
+        await _socket.OutputStream.FlushAsync(ct);
+        return true;
+    }
+
+    public async IAsyncEnumerable<(string PeerId, ReadOnlyMemory<byte> Data)> ReceiveAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _recvCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var buf = new byte[8192];
+        while (!_recvCts.IsCancellationRequested)
+        {
+            int read = await _socket!.InputStream.ReadAsync(buf, 0, buf.Length, _recvCts.Token);
+            if (read <= 0) break;
+            yield return ("peer", buf.AsMemory(0, read));
+        }
+    }
+
+    public Task StopAsync()
+    {
+        _socket?.Close();
+        _manager.RemoveGroup(_channel, null);
+        _recvCts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    // ---- IActionListener ----
+    public void OnSuccess()
+    {
+        (_pendingDiscover ?? _pendingConnect)?.TrySetResult(true);
+    }
+
+    public void OnFailure([GeneratedEnum] WifiP2pFailureReason reason)
+    {
+        (_pendingDiscover ?? _pendingConnect)?.TrySetResult(false);
+    }
+
+    // ---- IPeerListListener ----
+    public void OnPeersAvailable(WifiP2pDeviceList peers)
+    {
+        // Demonstration: auto-pick first device and connect (production code should show UI)
+        var first = peers.DeviceList.FirstOrDefault();
+        if (first is not null && _pendingConnect is null)
+            _ = ConnectToPeerAsync(first.DeviceAddress);
+    }
+
+    // ---- IConnectionInfoListener ----
+    public async void OnConnectionInfoAvailable(WifiP2pInfo info)
+    {
+        if (!info.GroupFormed) return;
+
+        if (info.IsGroupOwner)
+        {
+            var server = new ServerSocket(8988);
+            _socket = await server.AcceptAsync();
+        }
+        else
+        {
+            _socket = new Socket();
+            await _socket.ConnectAsync(new InetSocketAddress(info.GroupOwnerAddress, 8988), 10_000);
+        }
+
+        _pendingConnect?.TrySetResult(_socket?.IsConnected ?? false);
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/WifiP2pBroadcastReceiver.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/WifiP2pBroadcastReceiver.cs
@@ -1,0 +1,36 @@
+using Android.Content;
+using Android.Net.Wifi.P2p;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+sealed class WifiP2pBroadcastReceiver : BroadcastReceiver
+{
+    readonly WifiP2pManager _manager;
+    readonly WifiP2pManager.Channel _channel;
+    readonly WifiP2pManager.IPeerListListener _peers;
+    readonly WifiP2pManager.IConnectionInfoListener _conn;
+
+    public WifiP2pBroadcastReceiver(
+        WifiP2pManager manager,
+        WifiP2pManager.Channel channel,
+        WifiP2pManager.IPeerListListener peers,
+        WifiP2pManager.IConnectionInfoListener conn)
+    {
+        _manager = manager;
+        _channel = channel;
+        _peers = peers;
+        _conn = conn;
+    }
+
+    public override void OnReceive(Context? context, Intent? intent)
+    {
+        if (intent?.Action == WifiP2pManager.WifiP2pPeersChangedAction)
+        {
+            _manager.RequestPeers(_channel, _peers);
+        }
+        else if (intent?.Action == WifiP2pManager.WifiP2pConnectionChangedAction)
+        {
+            _manager.RequestConnectionInfo(_channel, _conn);
+        }
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -33,5 +33,11 @@
 <string>Scanning nearby BLE beacons.</string>
 <key>NFCReaderUsageDescription</key>
 <string>This app uses NFC to read and write tags.</string>
+<key>NSLocalNetworkUsageDescription</key>
+<string>Peer-to-peer communication with nearby devices.</string>
+<key>NSBonjourServices</key>
+<array>
+  <string>_maui-p2p._tcp</string>
+</array>
 </dict>
 </plist>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Services/MultipeerService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Services/MultipeerService.cs
@@ -1,0 +1,94 @@
+using Foundation;
+using MultipeerConnectivity;
+using QiMata.MobileIoT.Services;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace QiMata.MobileIoT.Platforms.iOS;
+
+public sealed class MultipeerService : NSObject, IP2PService, IMCSessionDelegate,
+                                        IMCNearbyServiceAdvertiserDelegate, IMCNearbyServiceBrowserDelegate
+{
+    readonly string _svcType = "maui-p2p";
+    readonly MCPeerID _self;
+    readonly MCSession _session;
+    readonly MCNearbyServiceAdvertiser _adv;
+    readonly MCNearbyServiceBrowser _browser;
+    readonly Channel<ReadOnlyMemory<byte>> _inbound = Channel.CreateUnbounded<ReadOnlyMemory<byte>>();
+
+    public MultipeerService()
+    {
+        _self = new MCPeerID(UIDevice.CurrentDevice.Name);
+        _session = new MCSession(_self, null, MCEncryptionPreference.Required);
+        _session.Delegate = this;
+
+        _adv = new MCNearbyServiceAdvertiser(_self, null, _svcType);
+        _adv.Delegate = this;
+
+        _browser = new MCNearbyServiceBrowser(_self, _svcType);
+        _browser.Delegate = this;
+    }
+
+    public Task<bool> StartDiscoveryAsync(CancellationToken ct = default)
+    {
+        _adv.StartAdvertisingPeer();
+        _browser.StartBrowsingForPeers();
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> ConnectToPeerAsync(string peerId, CancellationToken ct = default)
+    {
+        // Multipeer connects via invitations; browser sends invite automatically
+        return Task.FromResult(true);
+    }
+
+    public async Task<bool> SendAsync(ReadOnlyMemory<byte> buffer, string? peerId = null, CancellationToken ct = default)
+    {
+        var peers = _session.ConnectedPeers;
+        if (peers.Length == 0) return false;
+
+        var data = NSData.FromArray(buffer.ToArray());
+        NSError? err;
+        _session.SendData(data, peers, MCSessionSendDataMode.Reliable, out err);
+        return err is null;
+    }
+
+    public async IAsyncEnumerable<(string PeerId, ReadOnlyMemory<byte> Data)> ReceiveAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        while (await _inbound.Reader.WaitToReadAsync(ct))
+        {
+            while (_inbound.Reader.TryRead(out var mem))
+                yield return ("peer", mem);
+        }
+    }
+
+    public Task StopAsync()
+    {
+        _adv.StopAdvertisingPeer();
+        _browser.StopBrowsingForPeers();
+        _session.Disconnect();
+        return Task.CompletedTask;
+    }
+
+    // ---- Advertiser ----
+    public void DidReceiveInvitationFromPeer(MCNearbyServiceAdvertiser advertiser, MCPeerID peerID,
+                                             NSData? context, MCNearbyServiceInvitationHandler invitationHandler)
+        => invitationHandler(true, _session);
+
+    // ---- Browser ----
+    public void FoundPeer(MCNearbyServiceBrowser browser, MCPeerID peerID, NSDictionary info)
+        => browser.InvitePeer(peerID, _session, null, 20);
+
+    public void LostPeer(MCNearbyServiceBrowser browser, MCPeerID peerID) { }
+
+    // ---- Session ----
+    public void DidReceiveData(MCSession session, NSData data, MCPeerID peerID)
+        => _inbound.Writer.TryWrite(data.ToArray());
+
+    public void PeerChangedState(MCSession session, MCPeerID peerID, MCSessionState state) { }
+    public void DidReceiveStream(MCSession session, NSInputStream stream, string streamName, MCPeerID peerID) { }
+    public void DidStartReceivingResource(MCSession session, string resourceName, MCPeerID peerID,
+                                          NSProgress progress) { }
+    public void DidFinishReceivingResource(MCSession session, string resourceName, MCPeerID peerID,
+                                           NSUrl localUrl, NSError? error) { }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/I/IP2PService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/I/IP2PService.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT.Services;
+
+public interface IP2PService
+{
+    Task<bool> StartDiscoveryAsync(CancellationToken ct = default);
+    Task<bool> ConnectToPeerAsync(string peerId, CancellationToken ct = default);
+    Task<bool> SendAsync(ReadOnlyMemory<byte> buffer, string? peerId = null, CancellationToken ct = default);
+    IAsyncEnumerable<(string PeerId, ReadOnlyMemory<byte> Data)> ReceiveAsync(CancellationToken ct = default);
+    Task StopAsync();
+}

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/P2pViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/P2pViewModel.cs
@@ -1,0 +1,9 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QiMata.MobileIoT.Services;
+
+public partial class P2pViewModel(IP2PService p2p) : ObservableObject
+{
+    [RelayCommand] async Task Discover() => await p2p.StartDiscoveryAsync();
+    [RelayCommand] async Task SendPing() => await p2p.SendAsync("ping"u8.ToArray());
+}


### PR DESCRIPTION
## Summary
- introduce `IP2PService` abstraction
- register platform services in `MauiProgram`
- declare Wi‑Fi Direct permissions in Android manifest
- implement Android Wi‑Fi Direct service and permission helper
- implement iOS Multipeer service and Info.plist entries
- add sample `P2pViewModel`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*