### PR TITLE
Add USB serial support

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -57,10 +57,19 @@ namespace QiMata.MobileIoT
             builder.Services.AddTransient<ViewModels.BeaconScanViewModel>();
             builder.Services.AddTransient<BleScannerPage>();
 
+            builder.Services.AddTransient<ViewModels.UsbDemoViewModel>();
+            builder.Services.AddTransient<UsbDemoPage>();
+
 #if ANDROID
             builder.Services.AddSingleton<IP2PService, Platforms.Android.WifiDirectService>();
 #elif IOS
             builder.Services.AddSingleton<IP2PService, Platforms.iOS.MultipeerService>();
+#endif
+
+#if ANDROID
+            builder.Services.AddSingleton<IUsbSerialPort, Platforms.Android.UsbSerialPortAndroid>();
+#elif IOS
+            builder.Services.AddSingleton<IUsbSerialPort, Platforms.iOS.UsbSerialPortIos>();
 #endif
 
             return builder.Build();

--- a/src/MobileIoT/QiMata.MobileIoT/Models/UsbDeviceInfo.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Models/UsbDeviceInfo.cs
@@ -1,0 +1,3 @@
+namespace QiMata.MobileIoT.Services;
+
+public record UsbDeviceInfo(int VendorId, int ProductId, string Name);

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
         <uses-permission android:name="android.permission.NFC" />
         <uses-feature android:name="android.hardware.nfc" android:required="true" />
+        <uses-feature android:name="android.hardware.usb.host" android:required="false" />
 
   <application android:label="MyMauiApp">
     <activity android:name="crc64fa985e60e8a4f16e.MainActivity"
@@ -34,6 +35,11 @@
         <category android:name="android.intent.category.DEFAULT" />
         <data android:mimeType="application/vnd.yourapp.p2p" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+      </intent-filter>
+      <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                 android:resource="@xml/device_filter" />
     </activity>
   </application>
 

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Resources/xml/device_filter.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Resources/xml/device_filter.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="0x0403" product-id="0x6001" />
+    <usb-device vendor-id="0x2341" product-id="0x0043" />
+</resources>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbSerialPortAndroid.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbSerialPortAndroid.cs
@@ -1,0 +1,65 @@
+using Android.Content;
+using UsbSerialForAndroid;
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+public sealed class UsbSerialPortAndroid : IUsbSerialPort
+{
+    readonly Context _ctx = Android.App.Application.Context;
+    UsbSerialDevice? _device;
+    ISerialInputOutputManager? _ioManager;
+
+    public bool IsOpen => _device?.IsOpened ?? false;
+
+    public Task<IReadOnlyList<UsbDeviceInfo>> ListDevicesAsync(CancellationToken ct = default)
+    {
+        var mgr = UsbSerialProber.DefaultProber;
+        var drivers = mgr.FindAllDrivers(_ctx);
+        var list = drivers
+            .SelectMany(d => d.Ports)
+            .Select(p => new UsbDeviceInfo(
+                p.Driver.Device.VendorId,
+                p.Driver.Device.ProductId,
+                p.Driver.Device.DeviceName))
+            .ToList();
+        return Task.FromResult<IReadOnlyList<UsbDeviceInfo>>(list);
+    }
+
+    public Task<bool> OpenAsync(int vendorId, int productId, int baudRate = 115200, CancellationToken ct = default)
+    {
+        var prober = UsbSerialProber.DefaultProber;
+        var driver = prober.FindAllDrivers(_ctx)
+            .FirstOrDefault(d => d.Device.VendorId == vendorId && d.Device.ProductId == productId);
+        if (driver == null)
+            return Task.FromResult(false);
+
+        var connection = UsbManager.OpenDevice(driver.Device);
+        if (connection == null)
+            return Task.FromResult(false);
+
+        _device = driver.Ports.First();
+        _device.Open(connection);
+        _device.SetParameters(baudRate, 8, StopBits.One, Parity.None);
+
+        _ioManager = new SerialInputOutputManager(_device);
+        _ioManager.Start();
+
+        return Task.FromResult(true);
+    }
+
+    public Task<int> WriteAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        => Task.FromResult(_device?.Write(data.ToArray()) ?? 0);
+
+    public Task<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        => Task.FromResult(_device?.Read(buffer.Span) ?? 0);
+
+    public ValueTask DisposeAsync()
+    {
+        _ioManager?.Close();
+        _device?.Close();
+        _ioManager = null;
+        _device = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -39,5 +39,14 @@
 <array>
   <string>_maui-p2p._tcp</string>
 </array>
+<key>UISupportedExternalAccessoryProtocols</key>
+<array>
+    <string>com.yourcompany.yourdevice</string>
+</array>
+
+<key>UIBackgroundModes</key>
+<array>
+    <string>external-accessory</string>
+</array>
 </dict>
 </plist>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/UsbSerialPortIos.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/UsbSerialPortIos.cs
@@ -1,0 +1,61 @@
+using ExternalAccessory;
+using Foundation;
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.Platforms.iOS;
+
+public sealed class UsbSerialPortIos : IUsbSerialPort
+{
+    EAAccessory? _acc;
+    EASession? _session;
+    NSInputStream? _in;
+    NSOutputStream? _out;
+
+    public bool IsOpen => _session != null;
+
+    public Task<IReadOnlyList<UsbDeviceInfo>> ListDevicesAsync(CancellationToken ct = default)
+    {
+        var list = EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories
+            .Select(a => new UsbDeviceInfo(0, 0, a.Name))
+            .ToList();
+        return Task.FromResult<IReadOnlyList<UsbDeviceInfo>>(list);
+    }
+
+    public Task<bool> OpenAsync(int vid, int pid, int baud = 0, CancellationToken ct = default)
+    {
+        _acc = EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories
+            .FirstOrDefault(a => a.ProtocolStrings.Contains("com.yourcompany.yourdevice"));
+        if (_acc == null)
+            return Task.FromResult(false);
+
+        _session = new EASession(_acc, _acc.ProtocolStrings.First());
+        _in = _session.InputStream;
+        _out = _session.OutputStream;
+        _in?.Open();
+        _out?.Open();
+        return Task.FromResult(true);
+    }
+
+    public async Task<int> WriteAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        if (_out == null)
+            return 0;
+        var bytes = data.ToArray();
+        return await Task.Run(() => (int)_out.Write(bytes, 0, bytes.Length), ct);
+    }
+
+    public async Task<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+    {
+        if (_in == null || !_in.HasBytesAvailable)
+            return 0;
+        return await Task.Run(() => (int)_in.Read(buffer.Span), ct);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _in?.Close();
+        _out?.Close();
+        _session = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -64,6 +64,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
         <PackageReference Include="Plugin.NFC" Version="0.1.26" />
+        <PackageReference Include="UsbSerialForAndroid.Net" Version="3.3.0" />
       </ItemGroup>
 
         <ItemGroup>
@@ -93,10 +94,13 @@
 	  <Compile Update="Views\NfcP2PPage.xaml.cs">
 	    <DependentUpon>NfcP2PPage.xaml</DependentUpon>
 	  </Compile>
-	  <Compile Update="Views\WifiDirectPage.xaml.cs">
-	    <DependentUpon>WifiDirectPage.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
+          <Compile Update="Views\WifiDirectPage.xaml.cs">
+            <DependentUpon>WifiDirectPage.xaml</DependentUpon>
+          </Compile>
+          <Compile Update="Views\UsbDemoPage.xaml.cs">
+            <DependentUpon>UsbDemoPage.xaml</DependentUpon>
+          </Compile>
+        </ItemGroup>
 
 	<ItemGroup>
 	  <MauiXaml Update="Views\BeaconPage.xaml">
@@ -118,6 +122,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\BleScannerPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\UsbDemoPage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
         </ItemGroup>

--- a/src/MobileIoT/QiMata.MobileIoT/Services/IUsbSerialPort.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/IUsbSerialPort.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT.Services;
+
+public interface IUsbSerialPort : IAsyncDisposable
+{
+    Task<IReadOnlyList<UsbDeviceInfo>> ListDevicesAsync(CancellationToken ct = default);
+    Task<bool> OpenAsync(int vendorId, int productId, int baudRate = 115200, CancellationToken ct = default);
+    Task<int> WriteAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default);
+    Task<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default);
+    bool IsOpen { get; }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/UsbDemoViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/UsbDemoViewModel.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public partial class UsbDemoViewModel : ObservableObject
+{
+    readonly IUsbSerialPort _usb;
+
+    public UsbDemoViewModel(IUsbSerialPort usb)
+        => _usb = usb;
+
+    [ObservableProperty]
+    private string _log = string.Empty;
+
+    [RelayCommand]
+    private async Task ConnectAsync()
+    {
+        var devices = await _usb.ListDevicesAsync();
+        if (devices.Any() && await _usb.OpenAsync(devices[0].VendorId, devices[0].ProductId))
+            Log += $"Connected to {devices[0].Name}\n";
+        else
+            Log += "No device or failed to open.\n";
+    }
+
+    [RelayCommand]
+    private async Task SendPingAsync()
+    {
+        if (!_usb.IsOpen)
+            return;
+        await _usb.WriteAsync(new byte[] { 0x50, 0x49, 0x4E, 0x47 });
+        var buf = new byte[64];
+        int n = await _usb.ReadAsync(buf);
+        if (n > 0)
+            Log += $"RX {n} bytes\n";
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Views/UsbDemoPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/UsbDemoPage.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="QiMata.MobileIoT.Views.UsbDemoPage"
+             Title="USB Demo">
+    <VerticalStackLayout Padding="20">
+        <Button Text="Connect" Command="{Binding ConnectAsyncCommand}" />
+        <Button Text="Send Ping" Command="{Binding SendPingAsyncCommand}" />
+        <ScrollView>
+            <Label Text="{Binding Log}" LineBreakMode="WordWrap" />
+        </ScrollView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/MobileIoT/QiMata.MobileIoT/Views/UsbDemoPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/UsbDemoPage.xaml.cs
@@ -1,0 +1,12 @@
+using QiMata.MobileIoT.ViewModels;
+
+namespace QiMata.MobileIoT.Views;
+
+public partial class UsbDemoPage : ContentPage
+{
+    public UsbDemoPage(UsbDemoViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}


### PR DESCRIPTION
## Summary
- add UsbSerialForAndroid.Net to project
- define IUsbSerialPort abstraction and UsbDeviceInfo model
- implement Android and iOS USB serial ports
- register IUsbSerialPort implementations in DI
- expose sample UsbDemoViewModel and page
- update manifests for device attachment handling

## Testing
- `dotnet build src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj -t:Restore` *(fails: `dotnet: command not found`)*