### PR TITLE
Add USB communication infrastructure

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -4,6 +4,7 @@ using QiMata.MobileIoT.Services.I;
 using QiMata.MobileIoT.Services.Mock;
 using QiMata.MobileIoT.Services;
 using QiMata.MobileIoT.Views;
+using QiMata.MobileIoT.Usb;
 using Plugin.NFC;
 
 namespace QiMata.MobileIoT
@@ -45,6 +46,16 @@ namespace QiMata.MobileIoT
             builder.Services.AddSingleton<INfcP2PService, NfcP2PService_iOS>();
             builder.Services.AddSingleton<IP2PService, Platforms.iOS.MultipeerService>();
             builder.Services.AddSingleton<IUsbDeviceService, Platforms.iOS.UsbDeviceServiceIos>();
+#endif
+            builder.Services.AddSingleton<IUsbCommunicator>(provider =>
+#if ANDROID
+                new Platforms.Android.UsbCommunicatorAndroid()
+#elif IOS
+                new Platforms.iOS.UsbCommunicatoriOS()
+#else
+                throw new NotImplementedException()
+#endif
+            );
 #endif
 #endif
 

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <uses-permission android:name="android.permission.NFC" />
         <uses-feature android:name="android.hardware.nfc" android:required="true" />
         <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+        <uses-permission android:name="android.permission.USB_PERMISSION" tools:node="remove"/>
 
   <application android:label="MyMauiApp">
     <activity android:name="crc64fa985e60e8a4f16e.MainActivity"

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbCommunicatorAndroid.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbCommunicatorAndroid.cs
@@ -1,0 +1,44 @@
+#if ANDROID
+using Android.Content;
+using Android.Hardware.Usb;
+using Microsoft.Maui.ApplicationModel;
+using QiMata.MobileIoT.Usb;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+public sealed class UsbCommunicatorAndroid : IUsbCommunicator
+{
+    readonly UsbManager _mgr;
+    UsbDeviceConnection? _conn;
+    UsbEndpoint? _in;
+    UsbEndpoint? _out;
+
+    public UsbCommunicatorAndroid() =>
+        _mgr = (UsbManager)(Platform.CurrentActivity?.GetSystemService(Context.UsbService)
+               ?? Application.Context.GetSystemService(Context.UsbService))!;
+
+    public IEnumerable<UsbDeviceInfo> ListDevices() =>
+        _mgr.DeviceList.Values.Select(d => new UsbDeviceInfo(
+            d.DeviceName, d.VendorId, d.ProductId));
+
+    public bool OpenDevice(string id)
+    {
+        var dev = _mgr.DeviceList.Values.FirstOrDefault(d => d.DeviceName == id);
+        if (dev is null || !_mgr.HasPermission(dev)) return false;
+
+        var intf = dev.GetInterface(0);
+        _in = intf.GetEndpoint(0);
+        _out = intf.GetEndpoint(1);
+        _conn = _mgr.OpenDevice(dev);
+        return _conn?.ClaimInterface(intf, true) ?? false;
+    }
+
+    public int Write(byte[] data) =>
+        _conn?.BulkTransfer(_out!, data, data.Length, 1000) ?? -1;
+
+    public int Read(byte[] buff) =>
+        _conn?.BulkTransfer(_in!, buff, buff.Length, 1000) ?? -1;
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbPermissionReceiver.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbPermissionReceiver.cs
@@ -1,0 +1,14 @@
+using Android.Content;
+using Android.Hardware.Usb;
+using Microsoft.Maui.Controls;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+[BroadcastReceiver(Exported = true)]
+[IntentFilter(new[] { "USB_PERMISSION" })]
+public class UsbPermissionReceiver : BroadcastReceiver
+{
+    public override void OnReceive(Context context, Intent intent) =>
+        MessagingCenter.Send<object, bool>(this, "UsbPermissionResult",
+            intent.GetBooleanExtra(UsbManager.ExtraPermissionGranted, false));
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -41,7 +41,7 @@
 </array>
 <key>UISupportedExternalAccessoryProtocols</key>
 <array>
-    <string>com.yourcompany.yourprotocol</string>
+    <string>com.example.device.protocol1</string>
 </array>
 
 <key>UIBackgroundModes</key>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/UsbCommunicatoriOS.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/UsbCommunicatoriOS.cs
@@ -1,0 +1,34 @@
+#if IOS
+using ExternalAccessory;
+using Foundation;
+using QiMata.MobileIoT.Usb;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QiMata.MobileIoT.Platforms.iOS;
+
+public sealed class UsbCommunicatoriOS : IUsbCommunicator
+{
+    EAAccessory? _acc;  EASession? _sess;
+    NSInputStream? _in; NSOutputStream? _out;
+
+    public IEnumerable<UsbDeviceInfo> ListDevices() =>
+        EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories
+            .Select(a => new UsbDeviceInfo(a.SerialNumber, 0, 0));
+
+    public bool OpenDevice(string protocol)
+    {
+        _acc = EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories
+                  .FirstOrDefault(a => a.ProtocolStrings.Contains(protocol));
+        if (_acc is null) return false;
+
+        _sess = new EASession(_acc, protocol);
+        _in = _sess.InputStream;  _out = _sess.OutputStream;
+        _in?.Open();  _out?.Open();
+        return _in is not null && _out is not null;
+    }
+
+    public int Write(byte[] d) { _out?.Write(d, 0, d.Length); return d.Length; }
+    public int Read(byte[] b)  => _in?.Read(b, 0, b.Length) ?? -1;
+}
+#endif

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -64,6 +64,9 @@
         <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
       <PackageReference Include="Plugin.NFC" Version="0.1.26" />
+      <!-- Cross-platform USB libraries -->
+      <PackageReference Include="Device.Net" Version="5.*" />
+      <PackageReference Include="Usb.Net"    Version="5.*" />
       </ItemGroup>
 
         <ItemGroup>

--- a/src/MobileIoT/QiMata.MobileIoT/Usb/IUsbCommunicator.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Usb/IUsbCommunicator.cs
@@ -1,0 +1,9 @@
+namespace QiMata.MobileIoT.Usb;
+
+public interface IUsbCommunicator
+{
+    IEnumerable<UsbDeviceInfo> ListDevices();
+    bool OpenDevice(string idOrProtocol);
+    int  Write(byte[] data);
+    int  Read(byte[] buffer);
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Usb/UsbDeviceInfo.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Usb/UsbDeviceInfo.cs
@@ -1,0 +1,3 @@
+namespace QiMata.MobileIoT.Usb;
+
+public readonly record struct UsbDeviceInfo(string Id, int VendorId, int ProductId);

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/UsbViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/UsbViewModel.cs
@@ -1,0 +1,11 @@
+using QiMata.MobileIoT.Usb;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public class UsbViewModel(IUsbCommunicator usb)
+{
+    public IEnumerable<UsbDeviceInfo> Devices => usb.ListDevices();
+    public Task<bool> Connect(string id) => Task.FromResult(usb.OpenDevice(id));
+    public Task<int>  Send(byte[] d)    => Task.FromResult(usb.Write(d));
+    public Task<int>  Receive(byte[] b) => Task.FromResult(usb.Read(b));
+}


### PR DESCRIPTION
## Summary
- add Device.Net and Usb.Net packages
- declare USB host feature for Android and listen for permission results
- implement platform USB communicators for Android and iOS
- register `IUsbCommunicator` in DI
- expose a simple USB view model for binding

## Testing
- `dotnet build src/MobileIoT/MobileIoT.sln` *(fails: command not found)*