### PR TITLE
Add USB serial support

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -40,6 +40,7 @@ namespace QiMata.MobileIoT
             builder.Services.AddSingleton<IP2PService, Platforms.Android.WifiDirectService>();
             builder.Services.AddSingleton<IUsbDeviceService, Platforms.Android.UsbDeviceServiceAndroid>();
             builder.Services.AddSingleton<IUsbCommunicator,Platforms.Android.UsbCommunicatorAndroid>();
+            builder.Services.AddSingleton<ISerialDeviceService, Platforms.Android.UsbSerialDeviceService>();
 #elif IOS
             using QiMata.MobileIoT.Platforms.iOS;
             builder.Services.AddSingleton<IBeaconScanner, BeaconScanner_iOS>();
@@ -48,6 +49,7 @@ namespace QiMata.MobileIoT
             builder.Services.AddSingleton<IP2PService, Platforms.iOS.MultipeerService>();
             builder.Services.AddSingleton<IUsbDeviceService, Platforms.iOS.UsbDeviceServiceIos>();
             builder.Services.AddSingleton<IUsbCommunicator,Platforms.iOS.UsbCommunicatoriOS>();
+            builder.Services.AddSingleton<ISerialDeviceService, Platforms.iOS.ExternalAccessorySerialDeviceService>();
 #endif
 #endif
 

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -15,10 +15,11 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
         <uses-permission android:name="android.permission.NFC" />
         <uses-feature android:name="android.hardware.nfc" android:required="true" />
-        <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+        <uses-feature android:name="android.hardware.usb.host" android:required="true" />
         <uses-permission android:name="android.permission.USB_PERMISSION" tools:node="remove"/>
 
   <application android:label="MyMauiApp">
+    <receiver android:name="QiMata.MobileIoT.Platforms.Android.UsbPermissionBroadcastReceiver" />
     <activity android:name="crc64fa985e60e8a4f16e.MainActivity"
               android:exported="true"
               android:launchMode="singleTop">

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Resources/xml/device_filter.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/Resources/xml/device_filter.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Arduino Uno / Mega (CDC-ACM) -->
+    <usb-device vendor-id="0x2341" product-id="0x0043" />
+    <!-- FTDI FT232R -->
     <usb-device vendor-id="0x0403" product-id="0x6001" />
-    <usb-device vendor-id="0x067B" product-id="0x2303" />
+    <!-- CH340 -->
+    <usb-device vendor-id="0x1A86" product-id="0x7523" />
 </resources>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbPermissionBroadcastReceiver.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbPermissionBroadcastReceiver.cs
@@ -1,0 +1,24 @@
+using Android.App;
+using Android.Content;
+using Android.Hardware.Usb;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+[BroadcastReceiver(Exported = true)]
+[IntentFilter(new[] { UsbManager.ActionUsbDeviceAttached, ACTION_USB_PERMISSION })]
+public sealed class UsbPermissionBroadcastReceiver : BroadcastReceiver
+{
+    public const string ACTION_USB_PERMISSION = "com.qimata.mobileiot.USB_PERMISSION";
+
+    public override void OnReceive(Context context, Intent intent)
+    {
+        if (intent.Action != ACTION_USB_PERMISSION) return;
+
+        var granted = intent.GetBooleanExtra(UsbManager.ExtraPermissionGranted, false);
+        var device  = (UsbDevice?)intent.GetParcelableExtra(UsbManager.ExtraDevice);
+        if (granted && device != null)
+        {
+            UsbSerialDeviceService.UnblockPermission(device.DeviceId);
+        }
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbSerialDeviceService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/UsbSerialDeviceService.cs
@@ -1,0 +1,105 @@
+using Android.Content;
+using Android.Hardware.Usb;
+using Java.IO;
+using UsbSerialForAndroid; // NuGet/Xamarin binding
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.Platforms.Android;
+
+public sealed class UsbSerialDeviceService : ISerialDeviceService
+{
+    private const int READ_BUFF_SZ = 4096;
+
+    private readonly UsbManager _usb;
+    private UsbDeviceConnection? _conn;
+    private UsbSerialPort? _port;
+    private CancellationTokenSource? _rxCts;
+    private static readonly Dictionary<int, TaskCompletionSource> _permBlocks = new();
+
+    public UsbSerialDeviceService()
+    {
+        _usb = (UsbManager)Android.App.Application.Context.GetSystemService(Context.UsbService)!;
+    }
+
+    public bool IsOpen => _port?.IsOpen == true;
+
+    public async Task<IReadOnlyList<SerialDeviceInfo>> ListAsync(CancellationToken ct = default)
+    {
+        var list = new List<SerialDeviceInfo>();
+        foreach (var dev in _usb.DeviceList.Values)
+            list.Add(new SerialDeviceInfo((ushort)dev.VendorId, (ushort)dev.ProductId, dev.DeviceName));
+        return list;
+    }
+
+    public async Task<bool> OpenAsync(ushort vid, ushort pid, int baudRate = 9600, CancellationToken ct = default)
+    {
+        var dev = _usb.DeviceList.Values.FirstOrDefault(d => d.VendorId == vid && d.ProductId == pid);
+        if (dev == null) return false;
+
+        if (!_usb.HasPermission(dev))
+        {
+            var tcs = new TaskCompletionSource();
+            _permBlocks[dev.DeviceId] = tcs;
+
+            var pi = PendingIntent.GetBroadcast(Android.App.Application.Context, 0,
+                     new Intent(UsbPermissionBroadcastReceiver.ACTION_USB_PERMISSION),
+                     PendingIntentFlags.Immutable);
+            _usb.RequestPermission(dev, pi);
+            await tcs.Task.WaitAsync(ct);
+        }
+
+        _conn = _usb.OpenDevice(dev);
+        if (_conn == null) return false;
+
+        var driver = UsbSerialProber.DefaultProber.FindAllDrivers(_usb)
+                                                  .First(d => d.Device.DeviceId == dev.DeviceId);
+        _port = driver.Ports[0];
+        _port.Open(_conn);
+        _port.SetParameters(baudRate, 8, StopBits.One, Parity.None);
+
+        _rxCts = new CancellationTokenSource();
+        _ = Task.Run(() => RxLoop(_rxCts.Token), _rxCts.Token);
+        return true;
+    }
+
+    public Task<int> WriteAsync(byte[] data, CancellationToken ct = default)
+    {
+        if (_port == null) throw new InvalidOperationException("Port not open");
+        int sent = _port.Write(data, 1000);
+        return Task.FromResult(sent);
+    }
+
+    public event EventHandler<ReadOnlyMemory<byte>>? DataReceived;
+
+    private void RxLoop(CancellationToken token)
+    {
+        var buffer = new byte[READ_BUFF_SZ];
+        while (!token.IsCancellationRequested && _port != null)
+        {
+            try
+            {
+                int len = _port.Read(buffer, 100);
+                if (len > 0)
+                    DataReceived?.Invoke(this, new ReadOnlyMemory<byte>(buffer, 0, len));
+            }
+            catch (IOException)
+            {
+                break;
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _rxCts?.Cancel();
+        _port?.Close();
+        _conn?.Close();
+        _rxCts?.Dispose();
+    }
+
+    internal static void UnblockPermission(int deviceId)
+    {
+        if (_permBlocks.TryGetValue(deviceId, out var tcs))
+            tcs.TrySetResult();
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/ExternalAccessorySerialDeviceService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/ExternalAccessorySerialDeviceService.cs
@@ -1,0 +1,70 @@
+using ExternalAccessory;
+using Foundation;
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.Platforms.iOS;
+
+public sealed class ExternalAccessorySerialDeviceService : NSObject, ISerialDeviceService, INSStreamDelegate
+{
+    private const int READ_BUFF_SZ = 4096;
+    private EAAccessory? _acc;
+    private EASession? _session;
+
+    public bool IsOpen => _session != null;
+
+    public Task<IReadOnlyList<SerialDeviceInfo>> ListAsync(CancellationToken ct = default)
+    {
+        var list = EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories
+                     .Select(a => new SerialDeviceInfo(0, 0, a.Name))
+                     .ToList()
+                     .AsReadOnly();
+        return Task.FromResult<IReadOnlyList<SerialDeviceInfo>>(list);
+    }
+
+    public Task<bool> OpenAsync(ushort vid, ushort pid, int baudRate = 0, CancellationToken ct = default)
+    {
+        _acc = EAAccessoryManager.SharedAccessoryManager.ConnectedAccessories.FirstOrDefault();
+        if (_acc == null) return Task.FromResult(false);
+
+        var protocol = _acc.ProtocolStrings.First();
+        _session = new EASession(_acc, protocol);
+        _session.InputStream.Delegate  = this;
+        _session.OutputStream.Schedule(NSRunLoop.Current, NSRunLoop.NSDefaultRunLoopMode);
+        _session.InputStream.Schedule(NSRunLoop.Current, NSRunLoop.NSDefaultRunLoopMode);
+        _session.OutputStream.Open();
+        _session.InputStream.Open();
+        return Task.FromResult(true);
+    }
+
+    public Task<int> WriteAsync(byte[] data, CancellationToken ct = default)
+    {
+        if (_session == null) throw new InvalidOperationException("Not open");
+        var nsdata = NSData.FromArray(data);
+        _session.OutputStream.Write(nsdata.Bytes, (nuint)nsdata.Length);
+        return Task.FromResult(data.Length);
+    }
+
+    public event EventHandler<ReadOnlyMemory<byte>>? DataReceived;
+
+    [Export("stream:handleEvent:")]
+    public void HandleEvent(NSStream theStream, NSStreamEvent streamEvent)
+    {
+        if (streamEvent.HasFlag(NSStreamEvent.HasBytesAvailable))
+        {
+            var buffer = new byte[READ_BUFF_SZ];
+            nuint len = _session!.InputStream.Read(buffer, (nuint)buffer.Length);
+            if (len > 0)
+                DataReceived?.Invoke(this, new ReadOnlyMemory<byte>(buffer, 0, (int)len));
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _session?.InputStream.Close();
+        _session?.OutputStream.Close();
+        _session?.InputStream.RemoveFromRunLoop(NSRunLoop.Current, NSRunLoop.NSDefaultRunLoopMode);
+        _session?.OutputStream.RemoveFromRunLoop(NSRunLoop.Current, NSRunLoop.NSDefaultRunLoopMode);
+        _session = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/iOS/Info.plist
@@ -41,7 +41,7 @@
 </array>
 <key>UISupportedExternalAccessoryProtocols</key>
 <array>
-    <string>com.example.device.protocol1</string>
+    <string>com.redpark.cable.rs232</string>
 </array>
 
 <key>UIBackgroundModes</key>

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -67,6 +67,7 @@
       <!-- Cross-platform USB libraries -->
       <PackageReference Include="Device.Net" Version="4.2.1" />
       <PackageReference Include="Usb.Net"    Version="4.2.1" />
+      <PackageReference Include="UsbSerialForAndroid" Version="3.0.0" />
       </ItemGroup>
 
         <ItemGroup>

--- a/src/MobileIoT/QiMata.MobileIoT/Services/ISerialDeviceService.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/ISerialDeviceService.cs
@@ -1,0 +1,18 @@
+namespace QiMata.MobileIoT.Services;
+
+public interface ISerialDeviceService : IAsyncDisposable
+{
+    bool IsOpen { get; }
+
+    /// <summary>Enumerate attached USB-serial peripherals.</summary>
+    Task<IReadOnlyList<SerialDeviceInfo>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Open the first port matching VID/PID at the supplied baud rate.</summary>
+    Task<bool> OpenAsync(ushort vid, ushort pid, int baudRate = 9600, CancellationToken ct = default);
+
+    /// <summary>Write a byte payload.</summary>
+    Task<int> WriteAsync(byte[] data, CancellationToken ct = default);
+
+    /// <summary>Raised when bytes arrive from the peripheral.</summary>
+    event EventHandler<ReadOnlyMemory<byte>> DataReceived;
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Services/SerialDeviceInfo.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Services/SerialDeviceInfo.cs
@@ -1,0 +1,3 @@
+namespace QiMata.MobileIoT.Services;
+
+public record SerialDeviceInfo(ushort VendorId, ushort ProductId, string ProductName);

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/SerialDemoViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/SerialDemoViewModel.cs
@@ -1,0 +1,40 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QiMata.MobileIoT.Services;
+using System.Text;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public partial class SerialDemoViewModel : ObservableObject
+{
+    private readonly ISerialDeviceService _serial;
+
+    [ObservableProperty]
+    string _log = string.Empty;
+
+    public SerialDemoViewModel(ISerialDeviceService serial)
+    {
+        _serial = serial;
+        _serial.DataReceived += (_, mem) =>
+            Log += $"RX: {Encoding.ASCII.GetString(mem.Span)}{Environment.NewLine}";
+    }
+
+    [RelayCommand]
+    private async Task ConnectAsync()
+    {
+        var devices = await _serial.ListAsync();
+        if (devices.Count == 0) { Log += "No devices found\n"; return; }
+
+        var d = devices[0];
+        bool ok = await _serial.OpenAsync(d.VendorId, d.ProductId, 9600);
+        Log += ok ? "Connected\n" : "Open failed\n";
+    }
+
+    [RelayCommand]
+    private async Task SendAsync()
+    {
+        if (!_serial.IsOpen) { Log += "Not open\n"; return; }
+        await _serial.WriteAsync(Encoding.ASCII.GetBytes("LED_ON\n"));
+        Log += "TX: LED_ON\n";
+    }
+}


### PR DESCRIPTION
## Summary
- implement cross-platform `ISerialDeviceService`
- add Android USB serial implementation and permission receiver
- add iOS ExternalAccessory serial implementation
- wire new service into DI registration
- update Android and iOS manifests
- provide SerialDemoViewModel sample
- include UsbSerialForAndroid package

## Testing
- `dotnet build` *(fails: dotnet not installed)*