### PR TITLE
Fix Android manifest for MAUI

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/AndroidManifest.xml
@@ -11,38 +11,13 @@
         <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" tools:targetApi="31" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
-        <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
         <uses-permission android:name="android.permission.NFC" />
-        <uses-feature android:name="android.hardware.nfc" android:required="true" />
-        <uses-feature android:name="android.hardware.usb.host" android:required="true" />
-        <uses-permission android:name="android.permission.USB_PERMISSION" tools:node="remove"/>
+        <uses-feature android:name="android.hardware.nfc" android:required="false" />
+        <uses-feature android:name="android.hardware.usb.host" android:required="false" />
 
   <application android:label="MyMauiApp" android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
     <receiver android:name="QiMata.MobileIoT.Platforms.Android.UsbPermissionBroadcastReceiver" />
-    <activity android:name="crc64fa985e60e8a4f16e.MainActivity"
-              android:exported="true"
-              android:launchMode="singleTop">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="text/plain" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="application/vnd.yourapp.p2p" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
-      </intent-filter>
-      <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
-                 android:resource="@xml/device_filter" />
-    </activity>
   </application>
 
 </manifest>

--- a/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/MainActivity.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Platforms/Android/MainActivity.cs
@@ -1,6 +1,8 @@
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Nfc;
+using Android.Hardware.Usb;
 using Android.OS;
 using Plugin.NFC;
 
@@ -8,7 +10,18 @@ namespace QiMata.MobileIoT;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
           ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
-          ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+          ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density,
+          Exported = true)]
+[IntentFilter(
+    new[] { NfcAdapter.ActionNdefDiscovered },
+    Categories = new[] { Intent.CategoryDefault },
+    DataMimeType = "text/plain")]
+[IntentFilter(
+    new[] { NfcAdapter.ActionNdefDiscovered },
+    Categories = new[] { Intent.CategoryDefault },
+    DataMimeType = "application/vnd.yourapp.p2p")]
+[IntentFilter(new[] { UsbManager.ActionUsbDeviceAttached })]
+[MetaData("android.hardware.usb.action.USB_DEVICE_ATTACHED", Resource = "@xml/device_filter")]
 public partial class MainActivity : MauiAppCompatActivity
 {
     internal static event Action<int, string[], Permission[]>? PermissionsResultReceived;


### PR DESCRIPTION
## Summary
- rely on MAUI to provide MainActivity by removing activity entry from the manifest
- update required features and permissions
- add intent filters and metadata to `MainActivity`

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a68761b28832a9fc5c7958ad40d3b