### PR TITLE
Add BLE peripheral sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# mobileiot
+# MobileIoT
+
+This repository contains small .NET demos for Raspberry Pi. Under `src/pi/PiDemos` you can find examples including an iBeacon transmitter and a BLE GATT demo with a DHT22 sensor and LED.

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/PiDemo.BluetoothDemo.csproj
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/PiDemo.BluetoothDemo.csproj
@@ -1,10 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Linux.Bluetooth" Version="5.*" />
+    <PackageReference Include="System.Device.Gpio" />
+    <PackageReference Include="Iot.Device.Bindings" />
+  </ItemGroup>
 
 </Project>

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/Program.cs
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/Program.cs
@@ -1,2 +1,150 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+#nullable enable
+using System;
+using System.Device.Gpio;
+using System.Threading;
+using System.Threading.Tasks;
+using Iot.Device.DHTxx;
+using Linux.Bluetooth;
+using Linux.Bluetooth.Extensions;
+
+namespace PiBleDemo;
+
+/// <summary>Encapsulates GPIO + sensor resources.</summary>
+internal sealed class Hardware : IAsyncDisposable
+{
+    private readonly GpioController _gpio = new();
+    private readonly Dht22 _dht;
+    private readonly int _ledPin;
+
+    public Hardware(int dhtPin = 4, int ledPin = 17)
+    {
+        _dht = new Dht22(dhtPin, useFullSampling: true);
+        _ledPin = ledPin;
+        _gpio.OpenPin(_ledPin, PinMode.Output);
+        _gpio.Write(_ledPin, PinValue.Low);
+    }
+
+    public (double t, double h) ReadClimate()
+    {
+        if (!_dht.IsLastReadSuccessful) _dht.TryRead();
+        return (_dht.Temperature.DegreesCelsius, _dht.Humidity);
+    }
+
+    public void SetLed(bool on) => _gpio.Write(_ledPin, on ? PinValue.High : PinValue.Low);
+
+    public ValueTask DisposeAsync()
+    {
+        _gpio.Dispose();
+        _dht.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>BLE GATT characteristic for temperature / humidity.</summary>
+internal sealed class ClimateCharacteristic : GattLocalCharacteristic1
+{
+    private readonly Hardware _hw;
+
+    public ClimateCharacteristic(Hardware hw)
+        : base("e95d9250-251d-470a-a062-fa1922dfa9a8",
+               GattCharacteristicFlags.Read | GattCharacteristicFlags.Notify,
+               maxLength: 8)
+    {
+        _hw = hw;
+    }
+
+    protected override byte[] OnReadValue()
+    {
+        var (t, h) = _hw.ReadClimate();
+        Span<byte> data = stackalloc byte[8];
+        BitConverter.TryWriteBytes(data[..4], (float)t);
+        BitConverter.TryWriteBytes(data.Slice(4, 4), (float)h);
+        return data.ToArray();
+    }
+
+    public void PushNotification()
+    {
+        if (HasSubscribers)
+            Notify(OnReadValue());
+    }
+}
+
+/// <summary>Write-only LED characteristic (1 = on, 0 = off).</summary>
+internal sealed class LedCharacteristic : GattLocalCharacteristic1
+{
+    private readonly Hardware _hw;
+
+    public LedCharacteristic(Hardware hw)
+        : base("e95d93ee-251d-470a-a062-fa1922dfa9a8",
+               GattCharacteristicFlags.Write | GattCharacteristicFlags.WriteWithoutResponse,
+               maxLength: 1)
+    {
+        _hw = hw;
+    }
+
+    protected override void OnWriteValue(ReadOnlySpan<byte> value, GattRequestState state)
+    {
+        if (value.Length == 1) _hw.SetLed(value[0] != 0);
+    }
+}
+
+internal sealed class BleHost : IAsyncDisposable
+{
+    private readonly Hardware _hw;
+    private readonly ClimateCharacteristic _climate;
+    private readonly LedCharacteristic _led;
+    private readonly IDisposable _advHandle;
+
+    public BleHost(Hardware hw)
+    {
+        _hw = hw;
+        _climate = new ClimateCharacteristic(hw);
+        _led     = new LedCharacteristic(hw);
+
+        var service = new GattLocalService1(
+            "e95d93b0-251d-470a-a062-fa1922dfa9a8",
+            _climate, _led);
+
+        // Initialize BlueZ & register GATT service
+        BlueZManager.Initialize();
+        var adapter = BlueZManager.GetFirstAdapter();
+        var gattMgr = adapter.GetGattManager();
+        gattMgr.Register(service);
+
+        // Advertise with a complete name + service UUID
+        var advMgr = adapter.GetLEAdvertisingManager();
+        var adv = new LEAdvertisement
+        {
+            Type = LEAdvertisingType.Peripheral,
+            LocalName = "Pi-DHT-LED",
+            ServiceUUIDs = { service.UUID }
+        };
+        _advHandle = advMgr.RegisterAdvertisement(adv);
+        Console.WriteLine("BLE service started and advertising.");
+    }
+
+    public void Tick() => _climate.PushNotification();
+
+    public ValueTask DisposeAsync()
+    {
+        _advHandle.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal static class Program
+{
+    static async Task Main()
+    {
+        using var hw  = new Hardware();
+        await using var ble = new BleHost(hw);
+
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; timer.Dispose(); };
+
+        while (await timer.WaitForNextTickAsync())
+            ble.Tick();
+
+        Console.WriteLine("Shutting down cleanly.");
+    }
+}

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/README.md
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/README.md
@@ -1,0 +1,40 @@
+# Pi Bluetooth GATT Demo
+
+This project exposes a BLE service on a Raspberry Pi with:
+
+- Temperature and humidity from a DHT22 sensor (read/notify)
+- A writable LED toggle
+
+It relies on the [`Linux.Bluetooth`](https://www.nuget.org/packages/Linux.Bluetooth) D-Bus wrapper and the .NET IoT packages.
+
+## Building
+
+```bash
+# restore and publish a single-file binary
+dotnet publish -c Release -o publish --self-contained -r linux-arm64
+```
+
+Grant the Bluetooth capabilities so the process can use the adapter without running as root:
+
+```bash
+sudo setcap 'cap_net_raw,cap_net_admin+eip' publish/PiBleDemo
+```
+
+### Optional: systemd unit
+
+```ini
+[Service]
+ExecStart=/opt/pible/PiBleDemo
+Restart=always
+User=pi
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+```
+
+## Client contract
+
+| Item                   | UUID                                   | Properties     | Notes                           |
+| ---------------------- | -------------------------------------- | -------------- | ------------------------------- |
+| **Service**            | `e95d93b0-251d-470a-a062-fa1922dfa9a8` | –              | root container                  |
+| Temperature + Humidity | `e95d9250-251d-470a-a062-fa1922dfa9a8` | read, notify   | `float T`, `float RH`           |
+| LED control            | `e95d93ee-251d-470a-a062-fa1922dfa9a8` | write          | 1 byte: 0=off, 1=on             |
+```

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/grant_ble_capabilities.sh
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/grant_ble_capabilities.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Grant BLE capabilities to the published binary so it can manage the radio
+sudo setcap 'cap_net_raw,cap_net_admin+eip' /opt/pible/PiBleDemo

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/pible.service
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/pible.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Bluetooth DHT22/LED demo
+After=bluetooth.service
+
+[Service]
+Type=simple
+ExecStart=/opt/pible/PiBleDemo
+Restart=always
+User=pi
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+
+[Install]
+WantedBy=multi-user.target

--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/publish.sh
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/publish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Build a self-contained, single-file publish for Raspberry Pi (arm64)
+dotnet publish -c Release -o publish --self-contained -r linux-arm64


### PR DESCRIPTION
## Summary
- update bluetooth demo to provide a BLE GATT service
- add README and helper scripts for publishing and granting BLE capabilities
- update repo README with pointer to demos

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb9c7c8c0832a937dafbe88e16ad8