### PR TITLE
Fix BLE demo for updated libraries

### DIFF
--- a/src/pi/PiDemos/PiDemo.BluetoothDemo/PiDemo.BluetoothDemo.csproj
+++ b/src/pi/PiDemos/PiDemo.BluetoothDemo/PiDemo.BluetoothDemo.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Linux.Bluetooth" Version="5.*" />
     <PackageReference Include="System.Device.Gpio" />
     <PackageReference Include="Iot.Device.Bindings" />
+    <PackageReference Include="UnitsNet" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update Bluetooth demo for current Iot.Device.Bindings and Linux.Bluetooth APIs
- add UnitsNet package

## Testing
- `dotnet restore` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683cbee107d8832a83cd811ae5dc6102