### PR TITLE
Add USB demo scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ See `src/pi/README.md` or the script itself for full details and instructions.
 ## BLE Beacon Demo
 
 A Raspberry Pi can also act as a simple iBeacon for the .NET MAUI app. The Python script at `src/pi/beacon_demo.py` uses BlueZero to broadcast an iBeacon advertisement with the same UUID used elsewhere in the project. See `src/pi/BEACON_SETUP.md` for setup instructions.
+
+## USB Serial & Device Demos
+
+The Pi can also communicate with the MAUI app over USB. To enable this,
+configure the Pi for **USB gadget mode** (see `src/pi/README.md` for the
+exact steps). Two demos are provided:
+
+1. **USB Serial (CDC ACM)** – load the `g_serial` driver and run
+   `src/pi/serial_demo.py`. The mobile app sends the string `"LED_ON"` and
+   the script toggles an LED on GPIO17, replying with an acknowledgment.
+2. **USB Bulk Ping** – load the `g_zero` gadget. It echoes any bulk data
+   from the host so the MAUI app’s ping function receives the bytes back
+   immediately.
+
+The helper script `src/pi/run_serial_demo.sh` loads `g_serial` if needed
+and launches the Python demo.

--- a/src/pi/README.md
+++ b/src/pi/README.md
@@ -17,3 +17,29 @@ The script relies on the `bluezero`, `Adafruit_DHT` and `RPi.GPIO` packages. Ref
 ## BLE Beacon Demo
 
 The `beacon_demo.py` script turns the Raspberry Pi into an iBeacon transmitter so the MobileIoT app can detect it. The beacon uses the same base UUID as the other demos. See `BEACON_SETUP.md` for a full walkthrough on configuring the Pi and the expected advertisement format.
+
+## USB Serial Demo
+
+To control the Pi over USB as a virtual COM port, enable USB gadget mode
+and load the `g_serial` module. Once `/dev/ttyGS0` appears, run
+`serial_demo.py`:
+
+```bash
+sudo ./run_serial_demo.sh
+```
+
+The MAUI app sends `LED_ON` or `LED_OFF` commands which toggle an LED on
+GPIO17 and receive an acknowledgment string.
+
+## USB Device-Mode Ping Demo
+
+For a simple USB bulk transfer demo, load the `g_zero` gadget instead of
+`g_serial`:
+
+```bash
+sudo modprobe g_zero
+```
+
+No additional script is required – any data written to the bulk OUT
+endpoint is echoed back to the host so the app’s ping feature sees a
+response.

--- a/src/pi/run_serial_demo.sh
+++ b/src/pi/run_serial_demo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Simple helper to run the USB serial LED demo.
+# Loads the g_serial module if needed and launches the Python script.
+
+if ! grep -q '^g_serial ' /proc/modules; then
+    sudo modprobe g_serial
+fi
+
+sudo python3 "$(dirname "$0")/serial_demo.py"

--- a/src/pi/serial_demo.py
+++ b/src/pi/serial_demo.py
@@ -1,0 +1,30 @@
+import serial
+import time
+import RPi.GPIO as GPIO
+
+LED_PIN = 17
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(LED_PIN, GPIO.OUT, initial=GPIO.LOW)
+
+ser = serial.Serial('/dev/ttyGS0', 9600, timeout=1)
+print("Waiting for commands on /dev/ttyGS0...")
+
+try:
+    while True:
+        if ser.in_waiting:
+            line = ser.readline().decode('ascii', errors='ignore').strip()
+            if not line:
+                continue
+            print(f"Received: {line}")
+            if line == "LED_ON":
+                GPIO.output(LED_PIN, GPIO.HIGH)
+                ser.write(b"ACK: LED turned ON\n")
+            elif line == "LED_OFF":
+                GPIO.output(LED_PIN, GPIO.LOW)
+                ser.write(b"ACK: LED turned OFF\n")
+            else:
+                ser.write(b"NACK: Unknown command\n")
+        time.sleep(0.1)
+finally:
+    ser.close()
+    GPIO.cleanup()

--- a/src/pi/usb_demo.py
+++ b/src/pi/usb_demo.py
@@ -1,0 +1,9 @@
+"""Placeholder for the USB bulk demo.
+
+The Ping example in the MobileIoT app uses the Linux ``g_zero`` gadget,
+which echoes any data sent to it. Because the gadget handles the echo in
+the kernel, no Python code is required on the Pi. Load ``g_zero`` with
+``sudo modprobe g_zero`` and the MAUI app will be able to send and
+receive bytes on the bulk endpoints.
+"""
+


### PR DESCRIPTION
## Summary
- add Python script to handle USB serial commands
- document USB gadget setup in both READMEs
- add run script to start the serial demo
- clarify that g_zero requires no code

## Testing
- `python3 -m py_compile src/pi/*.py`
- `dotnet build src/MobileIoT/MobileIoT.sln -c Release` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ee0cce4b8832ab973f5d7495eb3b9