### PR TITLE
Add computer vision demo

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/AppShell.xaml.cs
@@ -17,6 +17,7 @@ namespace QiMata.MobileIoT
             Routing.RegisterRoute(nameof(SerialPage), typeof(QiMata.MobileIoT.Views.SerialPage));
             Routing.RegisterRoute(nameof(UsbPage), typeof(QiMata.MobileIoT.Views.UsbPage));
             Routing.RegisterRoute(nameof(WifiDirectPage), typeof(QiMata.MobileIoT.Views.WifiDirectPage));
+            Routing.RegisterRoute(nameof(VisionPage), typeof(QiMata.MobileIoT.Views.VisionPage));
         }
     }
 }

--- a/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml
@@ -80,6 +80,13 @@
                             Command="{Binding NavigateCommand}"
                             CommandParameter="WifiDirectPage" />
 
+                    <Button Text="Computer Vision"
+                            BackgroundColor="#2563EB"
+                            TextColor="White"
+                            CornerRadius="8"
+                            Command="{Binding NavigateCommand}"
+                            CommandParameter="VisionPage" />
+
                 </VerticalStackLayout>
             </Frame>
         </ScrollView>

--- a/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MainPage.xaml.cs
@@ -20,7 +20,8 @@ namespace QiMata.MobileIoT
                 ["NfcP2PPage"] = () => Task.FromResult(true),
                 ["UsbPage"] = () => Task.FromResult(true),
                 ["SerialPage"] = () => Task.FromResult(true),
-                ["WifiDirectPage"] = EnsurePermission<Permissions.NetworkState>
+                ["WifiDirectPage"] = EnsurePermission<Permissions.NetworkState>,
+                ["VisionPage"] = EnsurePermission<Permissions.Camera>
             };
 
             NavigateCommand = new Command<string>(async route => await NavigateToPage(route));

--- a/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/MauiProgram.cs
@@ -94,6 +94,9 @@ namespace QiMata.MobileIoT
             builder.Services.AddTransient<ViewModels.UsbViewModel>();
             builder.Services.AddTransient<UsbPage>();
 
+            builder.Services.AddTransient<ViewModels.VisionViewModel>();
+            builder.Services.AddTransient<VisionPage>();
+
             return builder.Build();
         }
     }

--- a/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
+++ b/src/MobileIoT/QiMata.MobileIoT/QiMata.MobileIoT.csproj
@@ -111,6 +111,9 @@
           <Compile Update="Views\WifiDirectPage.xaml.cs">
             <DependentUpon>WifiDirectPage.xaml</DependentUpon>
           </Compile>
+          <Compile Update="Views\VisionPage.xaml.cs">
+            <DependentUpon>VisionPage.xaml</DependentUpon>
+          </Compile>
         </ItemGroup>
 
 	<ItemGroup>
@@ -133,6 +136,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\BleScannerPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\VisionPage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
         </ItemGroup>

--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/VisionViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/VisionViewModel.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.ApplicationModel;
+using QiMata.MobileIoT.Services;
+
+namespace QiMata.MobileIoT.ViewModels;
+
+public partial class VisionViewModel(ImageClassificationService service) : ObservableObject
+{
+    private readonly ImageClassificationService _service = service;
+
+    [ObservableProperty]
+    ImageSource? photo;
+
+    [ObservableProperty]
+    string result = string.Empty;
+
+    [RelayCommand]
+    async Task CapturePhoto()
+    {
+        var file = await MediaPicker.CapturePhotoAsync();
+        if (file is null)
+            return;
+
+        Photo = ImageSource.FromFile(file.FullPath);
+        using var stream = await file.OpenReadAsync();
+        Result = _service.ClassifyImage(stream);
+    }
+
+    [RelayCommand]
+    Task NavigateBack() => Shell.Current.GoToAsync("..");
+}

--- a/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="QiMata.MobileIoT.Views.VisionPage"
+             Title="Computer Vision">
+    <VerticalStackLayout Padding="20" Spacing="12">
+        <Button Text="Capture Photo"
+                Command="{Binding CapturePhotoCommand}" />
+
+        <Image Source="{Binding Photo}" HeightRequest="200" />
+
+        <Label Text="{Binding Result}" FontSize="18" />
+
+        <Button Text="Back"
+                BackgroundColor="#6B7280"
+                TextColor="White"
+                Command="{Binding NavigateBackCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml.cs
@@ -1,0 +1,10 @@
+namespace QiMata.MobileIoT.Views;
+
+public partial class VisionPage : ContentPage
+{
+    public VisionPage(ViewModels.VisionViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}


### PR DESCRIPTION
## Summary
- add new VisionPage with simple photo capture and classification
- register VisionPage and ViewModel
- expose navigation button for new computer vision demo
- grant camera permission for the route

## Testing
- `dotnet build src/MobileIoT/MobileIoT.sln -c Release` *(fails: missing workloads)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec21d0f0832abeb9ec7c54e449e5