### PR TITLE
Add QR scanning to vision demo

### DIFF
--- a/src/MobileIoT/QiMata.MobileIoT/ViewModels/VisionViewModel.cs
+++ b/src/MobileIoT/QiMata.MobileIoT/ViewModels/VisionViewModel.cs
@@ -5,15 +5,19 @@ using QiMata.MobileIoT.Services;
 
 namespace QiMata.MobileIoT.ViewModels;
 
-public partial class VisionViewModel(ImageClassificationService service) : ObservableObject
+public partial class VisionViewModel(ImageClassificationService service, IQrScanningService qrScanner) : ObservableObject
 {
     private readonly ImageClassificationService _service = service;
+    private readonly IQrScanningService _qrScanner = qrScanner;
 
     [ObservableProperty]
     ImageSource? photo;
 
     [ObservableProperty]
     string result = string.Empty;
+
+    [ObservableProperty]
+    string qrResult = string.Empty;
 
     [RelayCommand]
     async Task CapturePhoto()
@@ -25,6 +29,14 @@ public partial class VisionViewModel(ImageClassificationService service) : Obser
         Photo = ImageSource.FromFile(file.FullPath);
         using var stream = await file.OpenReadAsync();
         Result = _service.ClassifyImage(stream);
+    }
+
+    [RelayCommand]
+    async Task ScanQr()
+    {
+        var code = await _qrScanner.ScanAsync();
+        if (code is not null)
+            QrResult = code;
     }
 
     [RelayCommand]

--- a/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml
+++ b/src/MobileIoT/QiMata.MobileIoT/Views/VisionPage.xaml
@@ -4,6 +4,11 @@
              x:Class="QiMata.MobileIoT.Views.VisionPage"
              Title="Computer Vision">
     <VerticalStackLayout Padding="20" Spacing="12">
+        <Button Text="Scan QR Code"
+                Command="{Binding ScanQrCommand}" />
+
+        <Label Text="{Binding QrResult}" FontSize="18" />
+
         <Button Text="Capture Photo"
                 Command="{Binding CapturePhotoCommand}" />
 


### PR DESCRIPTION
## Summary
- add IQrScanningService to VisionViewModel
- expose command and property for QR results
- update VisionPage with buttons for QR scan and image capture

## Testing
- `dotnet build src/MobileIoT/MobileIoT.sln -c Release` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840ee24ac0c832a9e57070e69514665